### PR TITLE
fix version compatibility so it's installable on ownCloud 8.1 / dev setups

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,6 +36,6 @@
 	<ocsid>169116</ocsid>
 	<dependencies>
 		<php min-version="5.4" max-version="5.6"/>
-		<owncloud min-version="8.0.2" max-version="8.0.99"/>
+		<owncloud min-version="8.0.2" max-version="8.1"/>
 	</dependencies>
 </info>


### PR DESCRIPTION
Please review @oparoz @DeepDiver1975 

I found two things though:
- the minimum ownCloud version required is 8.0.2? Is that correct, so it doesn’t work with 7? I guess we just have to leave those folks with the old Pictures app.
- it only supports IE11? If we really want to ship this as the default Gallery app, we _need_ to support IE8 … at least IE9. cc @MorrisJobke 
