### PR TITLE
Tweaks for fewer preview sizes and device rotation.

### DIFF
--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -62,6 +62,14 @@ var galleryFileAction = {
 		var width = Math.floor($(window).width() * window.devicePixelRatio);
 		var height = Math.floor($(window).height() * window.devicePixelRatio);
 
+		/* Find value of longest edge. */
+		var longEdge = Math.max( width, height );
+
+		/* Find the next larger image size. */
+		if ( longEdge % 100 !== 0 ){
+			longEdge = ( longEdge + 100 ) - ( longEdge % 100 );
+		}
+
 		for (var i = 0; i < files.length; i++) {
 			var file = files[i];
 			// We only add images to the slideshow if we think we'll be able
@@ -69,8 +77,8 @@ var galleryFileAction = {
 			if (galleryFileAction.mediaTypes[file.mimetype]) {
 				/* jshint camelcase: false */
 				var params = {
-					width: width,
-					height: height,
+					width: longEdge,
+					height: longEdge,
 					c: file.etag,
 					requesttoken: oc_requesttoken
 				};

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -59,8 +59,8 @@ var galleryFileAction = {
 		var start = 0;
 		var images = [];
 		var dir = context.dir + '/';
-		var width = Math.floor($(window).width() * window.devicePixelRatio);
-		var height = Math.floor($(window).height() * window.devicePixelRatio);
+		var width = Math.floor(screen.width * window.devicePixelRatio);
+		var height = Math.floor(screen.height * window.devicePixelRatio);
 
 		/* Find value of longest edge. */
 		var longEdge = Math.max( width, height );

--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -100,11 +100,20 @@
 		getPreviewUrl: function (fileId, etag) {
 			var width = $(window).width() * window.devicePixelRatio;
 			var height = $(window).height() * window.devicePixelRatio;
+
+			/* Find value of longest edge. */
+			var longEdge = Math.max( width, height );
+
+			/* Find the next larger image size. */
+			if ( longEdge % 100 !== 0 ){
+				longEdge = ( longEdge + 100 ) - ( longEdge % 100 );
+			}
+
 			/* jshint camelcase: false */
 			var params = {
 				c: etag,
-				width: width,
-				height: height,
+				width: longEdge,
+				height: longEdge,
 				requesttoken: oc_requesttoken
 			};
 			return this.buildGalleryUrl('preview', '/' + fileId, params);

--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -98,8 +98,8 @@
 		 * @return {string}
 		 */
 		getPreviewUrl: function (fileId, etag) {
-			var width = $(window).width() * window.devicePixelRatio;
-			var height = $(window).height() * window.devicePixelRatio;
+			var width = Math.floor(screen.width * window.devicePixelRatio);
+			var height = Math.floor(screen.height * window.devicePixelRatio);
 
 			/* Find value of longest edge. */
 			var longEdge = Math.max( width, height );

--- a/js/slideshowzoomablepreview.js
+++ b/js/slideshowzoomablepreview.js
@@ -45,7 +45,9 @@
 			var maxZoom = this.maxZoom;
 			var imgWidth = image.naturalWidth / window.devicePixelRatio;
 			var imgHeight = image.naturalHeight / window.devicePixelRatio;
-			if (imgWidth < this.smallImageDimension && imgHeight < this.smallImageDimension) {
+			if ( imgWidth < this.smallImageDimension &&
+			     imgHeight < this.smallImageDimension &&
+			     this.currentImage.mimeType !== 'image/svg+xml' ) {
 				maxZoom += 3;
 				this.currentImage.isSmallImage = true;
 			}
@@ -57,9 +59,9 @@
 				width: imgWidth,
 				height: imgHeight
 			}), image);
-			if (this.fullScreen === null && this.currentImage.mimeType !== 'image/svg+xml') {
-				this._resetZoom();
-			}
+
+			// Reset our zoom based on image and window dimensions.
+			this._resetZoom();
 
 			// prevent zoom-on-doubleClick
 			this.zoomable.addEventListener('dblclick', function (ie) {
@@ -118,7 +120,14 @@
 			}
 			if (this.currentImage.isSmallImage) {
 				this.zoomable.flyTo(0, 0, this.smallImageScale, true);
+			} else if ( $(window).width() < this.zoomable.width ||
+				    $(window).height() < this.zoomable.height ) {
+				// The image is larger than the window.
+				// Set minimum zoom and call flyZoomToFit.
+				this.zoomable.setMinZoom(this.zoomable.getZoomToFitValue());
+				this.zoomable.flyZoomToFit();
 			} else {
+				this.zoomable.setMinZoom(0);
 				this.zoomable.flyTo(0, 0, 0, true);
 			}
 		},
@@ -180,8 +189,18 @@
 			}
 			if (this.currentImage.isSmallImage) {
 				this.zoomable.setZoom(this.smallImageScale, true);
-			} else {
-				this.zoomable.setZoom(0, true);
+			} else if ( $(window).width() < this.zoomable.width || 
+			            $(window).height() < this.zoomable.height ||
+				    this.fullScreen !== null ||
+				    this.currentImage.mimeType === 'image/svg+xml' ) {
+				// The image is larger than the window, or we are fullScreen,
+				// or this is an SVG. Set minimum zoom and call zoomToFit.
+				this.zoomable.setMinZoom(this.zoomable.getZoomToFitValue());
+				this.zoomable.zoomToFit();
+			} else { 
+				// Zoom to the image size.
+				this.zoomable.setMinZoom(0);
+				this.zoomable.setZoom(0, true); 
 			}
 		},
 


### PR DESCRIPTION
Scale images in Bigshot that are larger than window.
Request preview sizes in multiples of 100.
Request preview sizes that still work when devices are rotated.
#157
#142
