### PR TITLE
Slideshow cleanup

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -168,3 +168,8 @@
 	filter: alpha(opacity=90);
 	opacity: .9;
 }
+
+#slideshow > .bigshotContainer {
+	width: 100%;
+	height: 100%;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,6 @@
 /* global OC, $, _, Gallery */
 $(document).ready(function () {
+	"use strict";
 	Gallery.hideSearch();
 	Gallery.utility = new Gallery.Utility();
 	Gallery.view = new Gallery.View();
@@ -17,7 +18,6 @@ $(document).ready(function () {
 		// Needed to centre the spinner in some browsers
 		Gallery.resetContentHeight();
 		Gallery.showLoading();
-
 		$.getJSON(Gallery.utility.buildGalleryUrl('config', '', {}))
 			.then(function (config) {
 				Gallery.config = new Gallery.Config(config);
@@ -76,6 +76,7 @@ $(document).ready(function () {
 });
 
 window.onhashchange = function () {
+	"use strict";
 	// The hash location is ALWAYS encoded
 	var path = decodeURIComponent(window.location.href.split('#')[1] || '');
 	var albumPath = OC.dirname(path);

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-/* global OC, $, _, Gallery */
+/* global OC, $, _, Gallery, SlideShow */
 $(document).ready(function () {
 	"use strict";
 	Gallery.hideSearch();
@@ -22,7 +22,12 @@ $(document).ready(function () {
 			.then(function (config) {
 				Gallery.config = new Gallery.Config(config);
 				Gallery.getFiles().then(function () {
-					window.onhashchange();
+					Gallery.activeSlideShow = new SlideShow();
+					$.when(Gallery.activeSlideShow.init(false, null))
+						.then(function () {
+							window.onhashchange();
+						});
+
 				});
 			});
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,4 +1,4 @@
-/* global Album, GalleryImage */
+/* global Album, GalleryImage, SlideShow */
 (function (OC, $, t) {
 	"use strict";
 	var Gallery = {
@@ -235,7 +235,7 @@
 		 *
 		 * @param event
 		 */
-		showSaveForm: function (event) {
+		showSaveForm: function () {
 			$(this).hide();
 			$('.save-form').css('display', 'inline');
 			$('#remote_address').focus();

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,4 +1,4 @@
-/* global OC, $, t, Album, GalleryImage, SlideShow, oc_requesttoken */
+/* global OC, $, t, Album, GalleryImage */
 var Gallery = {};
 Gallery.images = [];
 Gallery.currentAlbum = null;
@@ -8,6 +8,7 @@ Gallery.imageMap = {};
 Gallery.albumCache = {};
 Gallery.appName = 'galleryplus';
 Gallery.token = undefined;
+Gallery.activeSlideShow = null;
 
 /**
  * Builds a map of the albums located in the current folder
@@ -47,7 +48,7 @@ Gallery.refresh = function (path, albumPath) {
 		if (Gallery.activeSlideShow) {
 			Gallery.activeSlideShow.stop();
 		}
-	} else if (Gallery.imageMap[path] && !Gallery.activeSlideShow) {
+	} else if (Gallery.imageMap[path] && Gallery.activeSlideShow.active === false) {
 		Gallery.view.startSlideshow(path, albumPath);
 	}
 };
@@ -341,6 +342,7 @@ Gallery.resetContentHeight = function () {
  * @returns {boolean}
  */
 Gallery.slideShow = function (images, startImage, autoPlay) {
+	"use strict";
 	if (startImage === undefined) {
 		OC.Notification.showTemporary(t('gallery', 'Aborting preview. Could not find the file'));
 		return false;
@@ -371,21 +373,14 @@ Gallery.slideShow = function (images, startImage, autoPlay) {
 			downloadUrl: downloadUrl
 		};
 	});
-
-	var slideShow = new SlideShow($('#slideshow'), images);
-	slideShow.onStop = function () {
-		Gallery.activeSlideShow = null;
+	Gallery.activeSlideShow.setImages(images, autoPlay);
+	Gallery.activeSlideShow.onStop = function () {
 		$('#content').show();
 		if (Gallery.currentAlbum !== '') {
-			location.hash = encodeURIComponent(Gallery.currentAlbum);
+			history.replaceState('', '', '#' + encodeURIComponent(Gallery.currentAlbum));
 		} else {
-			location.hash = '!';
+			history.replaceState('', '', '#');
 		}
 	};
-	Gallery.activeSlideShow = slideShow;
-
-	slideShow.init(autoPlay);
-	slideShow.show(start);
+	Gallery.activeSlideShow.show(start);
 };
-
-Gallery.activeSlideShow = null;

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,386 +1,397 @@
-/* global OC, $, t, Album, GalleryImage */
-var Gallery = {};
-Gallery.images = [];
-Gallery.currentAlbum = null;
-Gallery.config = {};
-Gallery.albumMap = {};
-Gallery.imageMap = {};
-Gallery.albumCache = {};
-Gallery.appName = 'galleryplus';
-Gallery.token = undefined;
-Gallery.activeSlideShow = null;
-
-/**
- * Builds a map of the albums located in the current folder
- *
- * @param {string} path
- *
- * @returns {Album}
- */
-Gallery.getAlbum = function (path) {
-	if (!Gallery.albumMap[path]) {
-		Gallery.albumMap[path] = new Album(path, [], [], OC.basename(path));
-		// Attaches this album as a sub-album to the parent folder
-		if (path !== '') {
-			var parent = OC.dirname(path);
-			if (parent === path) {
-				parent = '';
-			}
-			Gallery.getAlbum(parent).subAlbums.push(Gallery.albumMap[path]);
-		}
-	}
-	return Gallery.albumMap[path];
-};
-
-/**
- * Refreshes the view and starts the slideshow if required
- *
- * @param {string} path
- * @param {string} albumPath
- */
-Gallery.refresh = function (path, albumPath) {
-	if (Gallery.currentAlbum !== albumPath) {
-		Gallery.view.init(albumPath);
-	}
-
-	// If the path is mapped, that means that it's an albumPath
-	if (Gallery.albumMap[path]) {
-		if (Gallery.activeSlideShow) {
-			Gallery.activeSlideShow.stop();
-		}
-	} else if (Gallery.imageMap[path] && Gallery.activeSlideShow.active === false) {
-		Gallery.view.startSlideshow(path, albumPath);
-	}
-};
-
-/**
- * Retrieves information about all the images and albums located in the current folder
- *
- * @returns {*}
- */
-Gallery.getFiles = function () {
-	var album, image, albumEtag;
-	Gallery.images = [];
-	Gallery.albumMap = {};
-	Gallery.imageMap = {};
-	var currentLocation = window.location.href.split('#')[1] || '';
-	var albumCache = Gallery.albumCache[decodeURIComponent(currentLocation)];
-	if (!$.isEmptyObject(albumCache)) {
-		albumEtag = albumCache.etag;
-	}
-	var params = {
-		location: currentLocation,
-		mediatypes: Gallery.config.getMediaTypes(),
-		features: Gallery.config.galleryFeatures,
-		etag: albumEtag
-	};
-	// Only use the folder as a GET parameter and not as part of the URL
-	var url = Gallery.utility.buildGalleryUrl('files', '', params);
-	return $.getJSON(url).then(function (/**{albuminfo}*/ data) {
-		var path = null;
-		var fileId = null;
-		var mimeType = null;
-		var mTime = null;
-		var etag = null;
-		var files = null;
-		var albumInfo = data.albuminfo;
-		Gallery.config.setAlbumConfig(albumInfo);
-		if (albumInfo.etag === albumEtag) {
-			Gallery.images = albumCache.images;
-			Gallery.imageMap = albumCache.imageMap;
-			Gallery.albumMap = albumCache.albumMap;
-		} else {
-			files = data.files;
-			for (var i = 0; i < files.length; i++) {
-				path = files[i].path;
-				fileId = files[i].fileid;
-				mimeType = files[i].mimetype;
-				mTime = files[i].mtime;
-				etag = files[i].etag;
-
-				Gallery.images.push(path);
-
-				image = new GalleryImage(path, path, fileId, mimeType, mTime, etag);
-				var dir = OC.dirname(path);
-				if (dir === path) {
-					dir = '';
-				}
-				album = Gallery.getAlbum(dir);
-				album.images.push(image);
-				Gallery.imageMap[image.path] = image;
-			}
-			Gallery.albumCache[albumInfo.path] = {
-				etag: albumInfo.etag,
-				files: files,
-				images: Gallery.images,
-				imageMap: Gallery.imageMap,
-				albumMap: Gallery.albumMap
-			};
-		}
-	}, function () {
-		// Triggered if we couldn't find a working folder
-		Gallery.view.element.empty();
-		Gallery.showEmpty();
-		Gallery.currentAlbum = null;
-	});
-};
-
-/**
- * Sorts albums and images based on user preferences
- */
-Gallery.sorter = function () {
-	var sortType = 'name';
-	var sortOrder = 'asc';
-	var albumSortType = 'name';
-	var albumSortOrder = 'asc';
-	if (this.id === 'sort-date-button') {
-		sortType = 'date';
-
-	}
-	var currentSort = Gallery.config.albumSorting;
-	if (currentSort.type === sortType && currentSort.order === sortOrder) {
-		sortOrder = 'des';
-	}
-
-	// Update the controls
-	Gallery.view.sortControlsSetup(sortType, sortOrder);
-
-	// We can't currently sort by album creation time
-	if (sortType === 'name') {
-		albumSortOrder = sortOrder;
-	}
-
-	// FIXME Rendering is still happening while we're sorting...
-
-	// Clear before sorting
-	Gallery.view.clear();
-
-	// Sort the images
-	Gallery.albumMap[Gallery.currentAlbum].images.sort(Gallery.utility.sortBy(sortType, sortOrder));
-	Gallery.albumMap[Gallery.currentAlbum].subAlbums.sort(Gallery.utility.sortBy(albumSortType,
-		albumSortOrder));
-
-	// Save the new settings
-	Gallery.config.updateAlbumSorting(sortType, sortOrder, albumSortOrder);
-
-	// Refresh the view
-	Gallery.view.viewAlbum(Gallery.currentAlbum);
-};
-
-/**
- * Populates the share dialog with the needed information
- *
- * @param event
- */
-Gallery.share = function (event) {
-	// Clicking on share button does not trigger automatic slide-up
-	$('.album-info-content').slideUp();
-
-	if (!OC.Share.droppedDown) {
-		event.preventDefault();
-		event.stopPropagation();
-
-		(function () {
-			var target = OC.Share.showLink;
-			OC.Share.showLink = function () {
-				var r = target.apply(this, arguments);
-				$('#linkText').val($('#linkText').val().replace('index.php/s/', 'index.php/apps/' +
-					Gallery.appName + '/s/'));
-
-				return r;
-			};
-		})();
-
-		var albumPermissions = Gallery.config.albumPermissions;
-		$('a.share').data('item', albumPermissions.fileid).data('link', true)
-			.data('possible-permissions', albumPermissions.permissions).
-			click();
-		if (!$('#linkCheckbox').is(':checked')) {
-			$('#linkText').hide();
-		}
-	}
-};
-
-/**
- * Sends an archive of the current folder to the browser
- *
- * @param event
- */
-Gallery.download = function (event) {
-	event.preventDefault();
-
-	var path = $('#content').data('albumname');
-	var files = Gallery.currentAlbum;
-	var downloadUrl = Gallery.utility.buildFilesUrl(path, files);
-
-	OC.redirect(downloadUrl);
-};
-
-/**
- * Shows an information box to the user
- *
- * @param event
- */
-Gallery.showInfo = function (event) {
-	event.stopPropagation();
-	Gallery.infoBox.showInfo();
-};
-
-/**
- * Lets the user add the shared files to his ownCloud
- *
- * @param event
- */
-Gallery.showSaveForm = function (event) {
-	$(this).hide();
-	$('.save-form').css('display', 'inline');
-	$('#remote_address').focus();
-};
-
-/**
- * Sends the shared files to the viewer's ownCloud
- *
- * @param event
- */
-Gallery.saveForm = function (event) {
-	event.preventDefault();
-
-	var saveElement = $('#save');
-	var remote = $(this).find('input[type="text"]').val();
-	var owner = saveElement.data('owner');
-	var name = saveElement.data('name');
-	var isProtected = saveElement.data('protected');
-	Gallery.saveToOwnCloud(remote, Gallery.token, owner, name, isProtected);
-};
-
-/**
- * Saves the folder to a remote ownCloud installation
- *
- * Our location is the remote for the other server
- *
- * @param {string} remote
- * @param {string}token
- * @param {string}owner
- * @param {string}name
- * @param {bool} isProtected
- */
-Gallery.saveToOwnCloud = function (remote, token, owner, name, isProtected) {
-	var location = window.location.protocol + '//' + window.location.host + OC.webroot;
-	var isProtectedInt = (isProtected) ? 1 : 0;
-	var url = remote + '/index.php/apps/files#' + 'remote=' + encodeURIComponent(location)
-		+ "&token=" + encodeURIComponent(token) + "&owner=" + encodeURIComponent(owner) + "&name=" +
-		encodeURIComponent(name) + "&protected=" + isProtectedInt;
-
-	if (remote.indexOf('://') > 0) {
-		OC.redirect(url);
-	} else {
-		// if no protocol is specified, we automatically detect it by testing https and http
-		// this check needs to happen on the server due to the Content Security Policy directive
-		$.get(OC.generateUrl('apps/files_sharing/testremote'),
-			{remote: remote}).then(function (protocol) {
-				if (protocol !== 'http' && protocol !== 'https') {
-					OC.dialogs.alert(t('files_sharing',
-							'No ownCloud installation (7 or higher) found at {remote}',
-							{remote: remote}),
-						t('files_sharing', 'Invalid ownCloud url'));
-				} else {
-					OC.redirect(protocol + '://' + url);
-				}
-			});
-	}
-};
-
-/**
- * Hide the search button while we wait for core to fix the templates
- */
-Gallery.hideSearch = function () {
-	$('form.searchbox').hide();
-};
-
-/**
- * Shows an empty gallery message
- */
-Gallery.showEmpty = function () {
-	$('#emptycontent').removeClass('hidden');
-	$('#controls').addClass('hidden');
-	$('#content').removeClass('icon-loading');
-};
-
-/**
- * Shows the infamous loading spinner
- */
-Gallery.showLoading = function () {
-	$('#emptycontent').addClass('hidden');
-	$('#controls').removeClass('hidden');
-	$('#content').addClass('icon-loading');
-};
-
-/**
- * Shows thumbnails
- */
-Gallery.showNormal = function () {
-	$('#emptycontent').addClass('hidden');
-	$('#controls').removeClass('hidden');
-	$('#content').removeClass('icon-loading');
-};
-
-/**
- * Resets the height of the content div so that the spinner can be centred
- */
-Gallery.resetContentHeight = function () {
-	// 200 is the space required for the footer and the browser toolbar
-	$('#content').css("min-height", $(window).height() - 200);
-};
-
-/**
- * Creates a new slideshow using the images found in the current folder
- *
- * @param {Array} images
- * @param {string} startImage
- * @param {bool} autoPlay
- *
- * @returns {boolean}
- */
-Gallery.slideShow = function (images, startImage, autoPlay) {
+/* global Album, GalleryImage */
+(function (OC, $, t) {
 	"use strict";
-	if (startImage === undefined) {
-		OC.Notification.showTemporary(t('gallery', 'Aborting preview. Could not find the file'));
-		return false;
-	}
-	var start = images.indexOf(startImage);
-	images = images.filter(function (image, index) {
-		// If the slideshow is loaded before we get a thumbnail, we have to accept all images
-		if (!image.thumbnail) {
-			return image;
-		} else {
-			if (image.thumbnail.valid) {
-				return image;
-			} else if (index < images.indexOf(startImage)) {
-				start--;
-			}
-		}
-	}).map(function (image) {
-		var name = OC.basename(image.path);
-		var previewUrl = Gallery.utility.getPreviewUrl(image.fileId, image.etag);
-		var downloadUrl = previewUrl + '&download';
+	var Gallery = {
+		images: [],
+		currentAlbum: null,
+		config: {},
+		albumMap: {},
+		imageMap: {},
+		albumCache: {},
+		appName: 'galleryplus',
+		token: undefined,
+		activeSlideShow: null,
 
-		return {
-			name: name,
-			path: image.path,
-			file: image.fileId,
-			mimeType: image.mimeType,
-			url: previewUrl,
-			downloadUrl: downloadUrl
-		};
-	});
-	Gallery.activeSlideShow.setImages(images, autoPlay);
-	Gallery.activeSlideShow.onStop = function () {
-		$('#content').show();
-		if (Gallery.currentAlbum !== '') {
-			history.replaceState('', '', '#' + encodeURIComponent(Gallery.currentAlbum));
-		} else {
-			history.replaceState('', '', '#');
+		/**
+		 * Builds a map of the albums located in the current folder
+		 *
+		 * @param {string} path
+		 *
+		 * @returns {Album}
+		 */
+		getAlbum: function (path) {
+			if (!Gallery.albumMap[path]) {
+				Gallery.albumMap[path] = new Album(path, [], [], OC.basename(path));
+				// Attaches this album as a sub-album to the parent folder
+				if (path !== '') {
+					var parent = OC.dirname(path);
+					if (parent === path) {
+						parent = '';
+					}
+					Gallery.getAlbum(parent).subAlbums.push(Gallery.albumMap[path]);
+				}
+			}
+			return Gallery.albumMap[path];
+		},
+
+		/**
+		 * Refreshes the view and starts the slideshow if required
+		 *
+		 * @param {string} path
+		 * @param {string} albumPath
+		 */
+		refresh: function (path, albumPath) {
+			if (Gallery.currentAlbum !== albumPath) {
+				Gallery.view.init(albumPath);
+			}
+
+			// If the path is mapped, that means that it's an albumPath
+			if (Gallery.albumMap[path]) {
+				if (Gallery.activeSlideShow) {
+					Gallery.activeSlideShow.stop();
+				}
+			} else if (Gallery.imageMap[path] && Gallery.activeSlideShow.active === false) {
+				Gallery.view.startSlideshow(path, albumPath);
+			}
+		},
+
+		/**
+		 * Retrieves information about all the images and albums located in the current folder
+		 *
+		 * @returns {*}
+		 */
+		getFiles: function () {
+			var album, image, albumEtag;
+			Gallery.images = [];
+			Gallery.albumMap = {};
+			Gallery.imageMap = {};
+			var currentLocation = window.location.href.split('#')[1] || '';
+			var albumCache = Gallery.albumCache[decodeURIComponent(currentLocation)];
+			if (!$.isEmptyObject(albumCache)) {
+				albumEtag = albumCache.etag;
+			}
+			var params = {
+				location: currentLocation,
+				mediatypes: Gallery.config.getMediaTypes(),
+				features: Gallery.config.galleryFeatures,
+				etag: albumEtag
+			};
+			// Only use the folder as a GET parameter and not as part of the URL
+			var url = Gallery.utility.buildGalleryUrl('files', '', params);
+			return $.getJSON(url).then(function (/**{albuminfo}*/ data) {
+				var path = null;
+				var fileId = null;
+				var mimeType = null;
+				var mTime = null;
+				var etag = null;
+				var files = null;
+				var albumInfo = data.albuminfo;
+				Gallery.config.setAlbumConfig(albumInfo);
+				if (albumInfo.etag === albumEtag) {
+					Gallery.images = albumCache.images;
+					Gallery.imageMap = albumCache.imageMap;
+					Gallery.albumMap = albumCache.albumMap;
+				} else {
+					files = data.files;
+					for (var i = 0; i < files.length; i++) {
+						path = files[i].path;
+						fileId = files[i].fileid;
+						mimeType = files[i].mimetype;
+						mTime = files[i].mtime;
+						etag = files[i].etag;
+
+						Gallery.images.push(path);
+
+						image = new GalleryImage(path, path, fileId, mimeType, mTime, etag);
+						var dir = OC.dirname(path);
+						if (dir === path) {
+							dir = '';
+						}
+						album = Gallery.getAlbum(dir);
+						album.images.push(image);
+						Gallery.imageMap[image.path] = image;
+					}
+					Gallery.albumCache[albumInfo.path] = {
+						etag: albumInfo.etag,
+						files: files,
+						images: Gallery.images,
+						imageMap: Gallery.imageMap,
+						albumMap: Gallery.albumMap
+					};
+				}
+			}, function () {
+				// Triggered if we couldn't find a working folder
+				Gallery.view.element.empty();
+				Gallery.showEmpty();
+				Gallery.currentAlbum = null;
+			});
+		},
+
+		/**
+		 * Sorts albums and images based on user preferences
+		 */
+		sorter: function () {
+			var sortType = 'name';
+			var sortOrder = 'asc';
+			var albumSortType = 'name';
+			var albumSortOrder = 'asc';
+			if (this.id === 'sort-date-button') {
+				sortType = 'date';
+
+			}
+			var currentSort = Gallery.config.albumSorting;
+			if (currentSort.type === sortType && currentSort.order === sortOrder) {
+				sortOrder = 'des';
+			}
+
+			// Update the controls
+			Gallery.view.sortControlsSetup(sortType, sortOrder);
+
+			// We can't currently sort by album creation time
+			if (sortType === 'name') {
+				albumSortOrder = sortOrder;
+			}
+
+			// FIXME Rendering is still happening while we're sorting...
+
+			// Clear before sorting
+			Gallery.view.clear();
+
+			// Sort the images
+			Gallery.albumMap[Gallery.currentAlbum].images.sort(Gallery.utility.sortBy(sortType,
+				sortOrder));
+			Gallery.albumMap[Gallery.currentAlbum].subAlbums.sort(Gallery.utility.sortBy(albumSortType,
+				albumSortOrder));
+
+			// Save the new settings
+			Gallery.config.updateAlbumSorting(sortType, sortOrder, albumSortOrder);
+
+			// Refresh the view
+			Gallery.view.viewAlbum(Gallery.currentAlbum);
+		},
+
+		/**
+		 * Populates the share dialog with the needed information
+		 *
+		 * @param event
+		 */
+		share: function (event) {
+			// Clicking on share button does not trigger automatic slide-up
+			$('.album-info-content').slideUp();
+
+			if (!OC.Share.droppedDown) {
+				event.preventDefault();
+				event.stopPropagation();
+
+				(function () {
+					var target = OC.Share.showLink;
+					OC.Share.showLink = function () {
+						var r = target.apply(this, arguments);
+						$('#linkText').val($('#linkText').val().replace('index.php/s/',
+							'index.php/apps/' +
+							Gallery.appName + '/s/'));
+
+						return r;
+					};
+				})();
+
+				var albumPermissions = Gallery.config.albumPermissions;
+				$('a.share').data('item', albumPermissions.fileid).data('link', true)
+					.data('possible-permissions', albumPermissions.permissions).
+					click();
+				if (!$('#linkCheckbox').is(':checked')) {
+					$('#linkText').hide();
+				}
+			}
+		},
+
+		/**
+		 * Sends an archive of the current folder to the browser
+		 *
+		 * @param event
+		 */
+		download: function (event) {
+			event.preventDefault();
+
+			var path = $('#content').data('albumname');
+			var files = Gallery.currentAlbum;
+			var downloadUrl = Gallery.utility.buildFilesUrl(path, files);
+
+			OC.redirect(downloadUrl);
+		},
+
+		/**
+		 * Shows an information box to the user
+		 *
+		 * @param event
+		 */
+		showInfo: function (event) {
+			event.stopPropagation();
+			Gallery.infoBox.showInfo();
+		},
+
+		/**
+		 * Lets the user add the shared files to his ownCloud
+		 *
+		 * @param event
+		 */
+		showSaveForm: function (event) {
+			$(this).hide();
+			$('.save-form').css('display', 'inline');
+			$('#remote_address').focus();
+		},
+
+		/**
+		 * Sends the shared files to the viewer's ownCloud
+		 *
+		 * @param event
+		 */
+		saveForm: function (event) {
+			event.preventDefault();
+
+			var saveElement = $('#save');
+			var remote = $(this).find('input[type="text"]').val();
+			var owner = saveElement.data('owner');
+			var name = saveElement.data('name');
+			var isProtected = saveElement.data('protected');
+			Gallery.saveToOwnCloud(remote, Gallery.token, owner, name, isProtected);
+		},
+
+		/**
+		 * Saves the folder to a remote ownCloud installation
+		 *
+		 * Our location is the remote for the other server
+		 *
+		 * @param {string} remote
+		 * @param {string}token
+		 * @param {string}owner
+		 * @param {string}name
+		 * @param {bool} isProtected
+		 */
+		saveToOwnCloud: function (remote, token, owner, name, isProtected) {
+			var location = window.location.protocol + '//' + window.location.host + OC.webroot;
+			var isProtectedInt = (isProtected) ? 1 : 0;
+			var url = remote + '/index.php/apps/files#' + 'remote=' + encodeURIComponent(location)
+				+ "&token=" + encodeURIComponent(token) + "&owner=" + encodeURIComponent(owner) +
+				"&name=" +
+				encodeURIComponent(name) + "&protected=" + isProtectedInt;
+
+			if (remote.indexOf('://') > 0) {
+				OC.redirect(url);
+			} else {
+				// if no protocol is specified, we automatically detect it by testing https and
+				// http
+				// this check needs to happen on the server due to the Content Security Policy
+				// directive
+				$.get(OC.generateUrl('apps/files_sharing/testremote'),
+					{remote: remote}).then(function (protocol) {
+						if (protocol !== 'http' && protocol !== 'https') {
+							OC.dialogs.alert(t('files_sharing',
+									'No ownCloud installation (7 or higher) found at {remote}',
+									{remote: remote}),
+								t('files_sharing', 'Invalid ownCloud url'));
+						} else {
+							OC.redirect(protocol + '://' + url);
+						}
+					});
+			}
+		},
+
+		/**
+		 * Hide the search button while we wait for core to fix the templates
+		 */
+		hideSearch: function () {
+			$('form.searchbox').hide();
+		},
+
+		/**
+		 * Shows an empty gallery message
+		 */
+		showEmpty: function () {
+			$('#emptycontent').removeClass('hidden');
+			$('#controls').addClass('hidden');
+			$('#content').removeClass('icon-loading');
+		},
+
+		/**
+		 * Shows the infamous loading spinner
+		 */
+		showLoading: function () {
+			$('#emptycontent').addClass('hidden');
+			$('#controls').removeClass('hidden');
+			$('#content').addClass('icon-loading');
+		},
+
+		/**
+		 * Shows thumbnails
+		 */
+		showNormal: function () {
+			$('#emptycontent').addClass('hidden');
+			$('#controls').removeClass('hidden');
+			$('#content').removeClass('icon-loading');
+		},
+
+		/**
+		 * Resets the height of the content div so that the spinner can be centred
+		 */
+		resetContentHeight: function () {
+			// 200 is the space required for the footer and the browser toolbar
+			$('#content').css("min-height", $(window).height() - 200);
+		},
+
+		/**
+		 * Creates a new slideshow using the images found in the current folder
+		 *
+		 * @param {Array} images
+		 * @param {string} startImage
+		 * @param {bool} autoPlay
+		 *
+		 * @returns {boolean}
+		 */
+		slideShow: function (images, startImage, autoPlay) {
+			if (startImage === undefined) {
+				OC.Notification.showTemporary(t('gallery',
+					'Aborting preview. Could not find the file'));
+				return false;
+			}
+			var start = images.indexOf(startImage);
+			images = images.filter(function (image, index) {
+				// If the slideshow is loaded before we get a thumbnail, we have to accept all
+				// images
+				if (!image.thumbnail) {
+					return image;
+				} else {
+					if (image.thumbnail.valid) {
+						return image;
+					} else if (index < images.indexOf(startImage)) {
+						start--;
+					}
+				}
+			}).map(function (image) {
+				var name = OC.basename(image.path);
+				var previewUrl = Gallery.utility.getPreviewUrl(image.fileId, image.etag);
+				var downloadUrl = previewUrl + '&download';
+
+				return {
+					name: name,
+					path: image.path,
+					file: image.fileId,
+					mimeType: image.mimeType,
+					url: previewUrl,
+					downloadUrl: downloadUrl
+				};
+			});
+			Gallery.activeSlideShow.setImages(images, autoPlay);
+			Gallery.activeSlideShow.onStop = function () {
+				$('#content').show();
+				if (Gallery.currentAlbum !== '') {
+					history.replaceState('', '', '#' + encodeURIComponent(Gallery.currentAlbum));
+				} else {
+					history.replaceState('', '', '#');
+				}
+			};
+			Gallery.activeSlideShow.show(start);
 		}
 	};
-	Gallery.activeSlideShow.show(start);
-};
+	window.Gallery = Gallery;
+}(OC, jQuery, t));

--- a/js/galleryconfig.js
+++ b/js/galleryconfig.js
@@ -1,5 +1,6 @@
-/* global $, Gallery */
-(function () {
+/* global Gallery */
+(function ($, Gallery) {
+	"use strict";
 	/**
 	 * Stores the gallery configuration
 	 *
@@ -167,4 +168,4 @@
 	};
 
 	Gallery.Config = Config;
-})();
+})(jQuery, Gallery);

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -1,5 +1,5 @@
 /* global oc_requesttoken, FileList, SlideShow */
-(function (OC ,OCA, $, oc_requesttoken) {
+(function (OC, OCA, $, oc_requesttoken) {
 	"use strict";
 	var galleryFileAction = {
 		config: null,
@@ -108,10 +108,17 @@
 			}
 
 			if ($.isEmptyObject(galleryFileAction.slideShow)) {
-				galleryFileAction.slideShow = new SlideShow($('#slideshow'));
-				galleryFileAction.slideShow.init(false, null);
+				galleryFileAction.slideShow = new SlideShow();
+				$.when(galleryFileAction.slideShow.init(false, null))
+					.then(function () {
+						galleryFileAction._startSlideshow(images, start);
+					});
+			} else {
+				galleryFileAction._startSlideshow(images, start);
 			}
+		},
 
+		_startSlideshow: function (images, start) {
 			galleryFileAction.slideShow.setImages(images);
 
 			var scrollTop = galleryFileAction.scrollContainer.scrollTop();
@@ -141,7 +148,7 @@
 	};
 
 	window.galleryFileAction = galleryFileAction;
-}(OC ,OCA, jQuery, oc_requesttoken));
+}(OC, OCA, jQuery, oc_requesttoken));
 
 $(document).ready(function () {
 	"use strict";

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -1,130 +1,167 @@
-/* global OC ,OCA, $, oc_requesttoken, SlideShow */
-var galleryFileAction = {
-	config: null,
-	mediaTypes: {},
+/* global oc_requesttoken, FileList, SlideShow */
+(function (OC ,OCA, $, oc_requesttoken) {
+	"use strict";
+	var galleryFileAction = {
+		config: null,
+		mediaTypes: {},
+		scrollContainer: null,
+		slideShow: null,
 
-	/**
-	 * Builds a URL pointing to one of the app's controllers
-	 *
-	 * @param {string} endPoint
-	 * @param {undefined|string} path
-	 * @param params
-	 *
-	 * @returns {string}
-	 */
-	buildGalleryUrl: function (endPoint, path, params) {
-		var extension = '';
-		var tokenElement = $('#sharingToken');
-		var token = (tokenElement.val()) ? tokenElement.val() : false;
-		if (token) {
-			params.token = token;
-			extension = '.public';
-		}
-		var query = OC.buildQueryString(params);
-		return OC.generateUrl('apps/galleryplus/' + endPoint + extension + path, null) + '?' +
-			query;
-	},
+		/**
+		 * Builds a URL pointing to one of the app's controllers
+		 *
+		 * @param {string} endPoint
+		 * @param {undefined|string} path
+		 * @param params
+		 *
+		 * @returns {string}
+		 */
+		buildGalleryUrl: function (endPoint, path, params) {
+			var extension = '';
+			var tokenElement = $('#sharingToken');
+			var token = (tokenElement.val()) ? tokenElement.val() : false;
+			if (token) {
+				params.token = token;
+				extension = '.public';
+			}
+			var query = OC.buildQueryString(params);
+			return OC.generateUrl('apps/galleryplus/' + endPoint + extension + path, null) + '?' +
+				query;
+		},
 
-	/**
-	 * Registers a file action for each media type
-	 *
-	 * @param mediaTypes
-	 */
-	register: function (mediaTypes) {
-		//console.log("enabledPreviewProviders: ", mediaTypes);
-		if (mediaTypes) {
-			galleryFileAction.mediaTypes = mediaTypes;
-		}
+		/**
+		 * Registers a file action for each media type
+		 *
+		 * @param mediaTypes
+		 */
+		register: function (mediaTypes) {
+			//console.log("enabledPreviewProviders: ", mediaTypes);
+			if (mediaTypes) {
+				galleryFileAction.mediaTypes = mediaTypes;
+			}
 
-		// We only want to create slideshows for supported media types
-		for (var i = 0, keys = Object.keys(galleryFileAction.mediaTypes); i < keys.length; i++) {
-			// Each click handler gets the same function and images array and
-			// is responsible to load the slideshow
-			OCA.Files.fileActions.register(keys[i], 'View', OC.PERMISSION_READ, '',
-				galleryFileAction.onView);
-			OCA.Files.fileActions.setDefault(keys[i], 'View');
-		}
-	},
+			// We only want to create slideshows for supported media types
+			for (var i = 0, keys = Object.keys(galleryFileAction.mediaTypes); i <
+			keys.length; i++) {
+				// Each click handler gets the same function and images array and
+				// is responsible to load the slideshow
+				OCA.Files.fileActions.register(keys[i], 'View', OC.PERMISSION_READ, '',
+					galleryFileAction.onView);
+				OCA.Files.fileActions.setDefault(keys[i], 'View');
+			}
+		},
 
-	/**
-	 * Builds an array containing all the images we can show in the slideshow
-	 *
-	 * @param {string} filename
-	 * @param context
-	 */
-	onView: function (filename, context) {
-		var imageUrl, downloadUrl;
-		var fileList = context.fileList;
-		var files = fileList.files;
-		var start = 0;
-		var images = [];
-		var dir = context.dir + '/';
-		var width = Math.floor(screen.width * window.devicePixelRatio);
-		var height = Math.floor(screen.height * window.devicePixelRatio);
+		/**
+		 * Builds an array containing all the images we can show in the slideshow
+		 *
+		 * @param {string} filename
+		 * @param context
+		 */
+		onView: function (filename, context) {
+			var imageUrl, downloadUrl;
+			var fileList = context.fileList;
+			var files = fileList.files;
+			var start = 0;
+			var images = [];
+			var dir = context.dir + '/';
+			var width = Math.floor(screen.width * window.devicePixelRatio);
+			var height = Math.floor(screen.height * window.devicePixelRatio);
 
-		/* Find value of longest edge. */
-		var longEdge = Math.max(width, height);
+			/* Find value of longest edge. */
+			var longEdge = Math.max(width, height);
 
-		/* Find the next larger image size. */
-		if (longEdge % 100 !== 0) {
-			longEdge = ( longEdge + 100 ) - ( longEdge % 100 );
-		}
+			/* Find the next larger image size. */
+			if (longEdge % 100 !== 0) {
+				longEdge = ( longEdge + 100 ) - ( longEdge % 100 );
+			}
 
-		for (var i = 0; i < files.length; i++) {
-			var file = files[i];
-			// We only add images to the slideshow if we think we'll be able
-			// to generate previews for this media type
-			if (galleryFileAction.mediaTypes[file.mimetype]) {
-				/* jshint camelcase: false */
-				var params = {
-					width: longEdge,
-					height: longEdge,
-					c: file.etag,
-					requesttoken: oc_requesttoken
-				};
-				imageUrl = galleryFileAction.buildGalleryUrl('preview', '/' + file.id, params);
-				downloadUrl = imageUrl + '&download';
+			for (var i = 0; i < files.length; i++) {
+				var file = files[i];
+				// We only add images to the slideshow if we think we'll be able
+				// to generate previews for this media type
+				if (galleryFileAction.mediaTypes[file.mimetype]) {
+					/* jshint camelcase: false */
+					var params = {
+						width: longEdge,
+						height: longEdge,
+						c: file.etag,
+						requesttoken: oc_requesttoken
+					};
+					imageUrl = galleryFileAction.buildGalleryUrl('preview', '/' + file.id, params);
+					downloadUrl = imageUrl + '&download';
 
-				images.push({
-					name: file.name,
-					path: dir + file.name,
-					fileId: file.id,
-					mimeType: file.mimetype,
-					url: imageUrl,
-					downloadUrl: downloadUrl
+					images.push({
+						name: file.name,
+						path: dir + file.name,
+						fileId: file.id,
+						mimeType: file.mimetype,
+						url: imageUrl,
+						downloadUrl: downloadUrl
+					});
+				}
+			}
+			for (i = 0; i < images.length; i++) {
+				//console.log("Images in the slideshow : ", images[i]);
+				if (images[i].name === filename) {
+					start = i;
+				}
+			}
+
+			if ($.isEmptyObject(galleryFileAction.slideShow)) {
+				galleryFileAction.slideShow = new SlideShow($('#slideshow'));
+				galleryFileAction.slideShow.init(false, null);
+			}
+
+			galleryFileAction.slideShow.setImages(images);
+
+			var scrollTop = galleryFileAction.scrollContainer.scrollTop();
+			// This is only called when the slideshow is stopped
+			galleryFileAction.slideShow.onStop = function () {
+				// Adding to the history will add a new URL every time the slideshow is launched
+				/*history.pushState('', document.title,
+				 window.location.pathname + window.location.search + '#');*/
+
+				FileList.$fileList.one('updated', function () {
+					galleryFileAction.scrollContainer.scrollTop(scrollTop);
 				});
-			}
-		}
-		for (i = 0; i < images.length; i++) {
-			//console.log("Images in the slideshow : ", images[i]);
-			if (images[i].name === filename) {
-				start = i;
-			}
-		}
-		var slideShow = new SlideShow($('#slideshow'), images);
-		slideShow.onStop = function () {
-			history.replaceState('', document.title,
-				window.location.pathname + window.location.search);
-		};
-		slideShow.init();
-		slideShow.show(start);
-	}
+			};
 
-};
+			// This stores the fileslist in the history state
+			var stateData = {
+				dir: FileList.getCurrentDirectory()
+			};
+			history.replaceState(stateData, document.title, window.location);
+
+			// This creates a new entry in history for the slideshow. It will
+			// be updated as the user navigates from picture to picture
+			history.pushState(null, '', '#loading');
+
+			galleryFileAction.slideShow.show(start);
+		}
+	};
+
+	window.galleryFileAction = galleryFileAction;
+}(OC ,OCA, jQuery, oc_requesttoken));
 
 $(document).ready(function () {
+	"use strict";
 	// Deactivates fileaction on public preview page
 	if ($('#imgframe').length > 0) {
 		return true;
 	}
 
+	window.galleryFileAction.scrollContainer = $('#app-content');
+	if ($('#isPublic').val()) {
+		window.galleryFileAction.scrollContainer = $(window);
+	}
+
 	// We're also asking for a list of supported media types.
 	// Media files are retrieved through the Files context
-	var url = galleryFileAction.buildGalleryUrl('config', '', {slideshow: 1});
+	var url = window.galleryFileAction.buildGalleryUrl('config', '', {slideshow: 1});
 	$.getJSON(url).then(function (config) {
 		if (!$.isEmptyObject(config.features)) {
-			galleryFileAction.config = config.features;
+			window.galleryFileAction.config = config.features;
 		}
-		galleryFileAction.register(config.mediatypes);
+		window.galleryFileAction.register(config.mediatypes);
 	});
 });

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -1,6 +1,6 @@
-/* global OC, t, $, _, Gallery */
-(function () {
-
+/* global Gallery, SlideShow */
+(function (OC, t, $, _) {
+	"use strict";
 	/**
 	 * Builds and updates the Gallery view
 	 *
@@ -44,6 +44,8 @@
 					$('#sort-date-button').click(Gallery.sorter);
 					$('#save #save-button').click(Gallery.showSaveForm);
 					$('.save-form').submit(Gallery.saveForm);
+					Gallery.activeSlideShow = new SlideShow($('#slideshow'));
+					Gallery.activeSlideShow.init(false, null);
 				}
 				this.viewAlbum(albumPath);
 			}
@@ -272,4 +274,4 @@
 	};
 
 	Gallery.View = View;
-})();
+})(OC, t, jQuery, _);

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -1,4 +1,4 @@
-/* global Gallery, SlideShow */
+/* global Gallery */
 (function (OC, t, $, _) {
 	"use strict";
 	/**
@@ -44,8 +44,6 @@
 					$('#sort-date-button').click(Gallery.sorter);
 					$('#save #save-button').click(Gallery.showSaveForm);
 					$('.save-form').submit(Gallery.saveForm);
-					Gallery.activeSlideShow = new SlideShow($('#slideshow'));
-					Gallery.activeSlideShow.init(false, null);
 				}
 				this.viewAlbum(albumPath);
 			}

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -1,20 +1,19 @@
-/* global $, SlideShow */
-(function () {
+/* global SlideShow */
+(function ($, SlideShow) {
+	"use strict";
 	/**
 	 * Button and key controls for the slideshow
 	 *
 	 * @param {object} slideshow
 	 * @param {*} container
 	 * @param {object} zoomablePreview
-	 * @param {array} images
 	 * @param {int} interval
 	 * @constructor
 	 */
-	var Controls = function (slideshow, container, zoomablePreview, images, interval) {
+	var Controls = function (slideshow, container, zoomablePreview, interval) {
 		this.slideshow = slideshow;
 		this.container = container;
 		this.zoomablePreview = zoomablePreview;
-		this.images = images;
 		this.progressBar = container.find('.progress');
 		this.interval = interval || 5000;
 
@@ -29,20 +28,8 @@
 
 		/**
 		 * Initialises the controls
-		 *
-		 * @param {bool} play
 		 */
-		init: function (play) {
-			this.active = true;
-			// hide arrows and play/pause when only one pic
-			this.container.find('.next, .previous').toggle(this.images.length > 1);
-			if (this.images.length === 1) {
-				this.container.find('.play, .pause').hide();
-			}
-
-			// Hide the toggle background button until we have something to show
-			this.container.find('.changeBackground').hide();
-
+		init: function () {
 			var makeCallBack = function (handler) {
 				return function (evt) {
 					if (!this.active) {
@@ -56,6 +43,25 @@
 			this._buttonSetup(makeCallBack);
 			this._specialButtonSetup(makeCallBack);
 			this._keyCodeSetup(makeCallBack);
+		},
+
+		/**
+		 * Updates the controls
+		 *
+		 * @param {{name:string, url: string, path: string, fallBack: string}[]} images
+		 * @param {bool} play
+		 */
+		update: function (images, play) {
+			this.images = images;
+			this.active = true;
+			// hide arrows and play/pause when only one pic
+			this.container.find('.next, .previous').toggle(this.images.length > 1);
+			if (this.images.length === 1) {
+				this.container.find('.play, .pause').hide();
+			}
+
+			// Hide the toggle background button until we have something to show
+			this.container.find('.changeBackground').hide();
 
 			if (play) {
 				this._play();
@@ -63,6 +69,7 @@
 				this._pause();
 			}
 		},
+
 		/**
 		 * Initialises local variables when the show starts
 		 *
@@ -74,6 +81,18 @@
 			if (this.playing) {
 				this._setTimeout();
 			}
+		},
+
+		/**
+		 * Stops the timed slideshow
+		 */
+		stop: function () {
+			this.slideshow.stop();
+			this.zoomablePreview.stop();
+
+			this._clearTimeout();
+			this.container.hide();
+			this.active = false;
 		},
 
 		/**
@@ -96,10 +115,9 @@
 		_buttonSetup: function (makeCallBack) {
 			this.container.children('.next').click(makeCallBack(this._next));
 			this.container.children('.previous').click(makeCallBack(this._previous));
-			this.container.children('.exit').click(makeCallBack(this._stop));
+			this.container.children('.exit').click(makeCallBack(this._exit));
 			this.container.children('.pause').click(makeCallBack(this._pause));
 			this.container.children('.play').click(makeCallBack(this._play));
-			//this.container.click(makeCallBack(this.next));
 		},
 
 		/**
@@ -262,16 +280,17 @@
 		},
 
 		/**
-		 * Stops the timed slideshow
+		 * Exits the slideshow by going back in history
 		 * @private
 		 */
-		_stop: function () {
-			this.slideshow.stop();
-			this.zoomablePreview.stop();
-
-			this._clearTimeout();
-			this.container.hide();
-			this.active = false;
+		_exit: function () {
+			// We simulate a click on the back button in order to be consistent
+			if (history) {
+				window.history.back();
+			} else{
+				// For ancient browsers supported in core
+				this.stop();
+			}
 		},
 
 		/**
@@ -322,4 +341,4 @@
 	};
 
 	SlideShow.Controls = Controls;
-})();
+})(jQuery, SlideShow);

--- a/js/slideshowzoomablepreview.js
+++ b/js/slideshowzoomablepreview.js
@@ -1,6 +1,6 @@
-/* global $, SlideShow, bigshot*/
-(function () {
-
+/* global SlideShow, bigshot*/
+(function ($, SlideShow, bigshot) {
+	"use strict";
 	/**
 	 * Creates a zoomable preview
 	 *
@@ -10,6 +10,8 @@
 	var ZoomablePreview = function (container) {
 		this.container = container;
 		this.element = this.container.get(0);
+		var bigshotContainer = container.find('.bigshotContainer');
+		this.bigshotElement = bigshotContainer.get(0);
 
 		this._detectFullscreen();
 		this._setupControls();
@@ -22,6 +24,8 @@
 	ZoomablePreview.prototype = {
 		container: null,
 		element: null,
+		bigshotContainer: null,
+		bigshotElement: null,
 		zoomable: null,
 		fullScreen: null,
 		canFullScreen: false,
@@ -52,7 +56,7 @@
 				this.currentImage.isSmallImage = true;
 			}
 			this.zoomable = new bigshot.SimpleImage(new bigshot.ImageParameters({
-				container: this.element,
+				container: this.bigshotElement,
 				maxZoom: maxZoom,
 				minZoom: 0,
 				touchUI: false,
@@ -235,4 +239,4 @@
 	};
 
 	SlideShow.ZoomablePreview = ZoomablePreview;
-})();
+})(jQuery, SlideShow, bigshot);

--- a/js/slideshowzoomablepreview.js
+++ b/js/slideshowzoomablepreview.js
@@ -49,9 +49,9 @@
 			var maxZoom = this.maxZoom;
 			var imgWidth = image.naturalWidth / window.devicePixelRatio;
 			var imgHeight = image.naturalHeight / window.devicePixelRatio;
-			if ( imgWidth < this.smallImageDimension &&
-			     imgHeight < this.smallImageDimension &&
-			     this.currentImage.mimeType !== 'image/svg+xml' ) {
+			if (imgWidth < this.smallImageDimension &&
+				imgHeight < this.smallImageDimension &&
+				this.currentImage.mimeType !== 'image/svg+xml') {
 				maxZoom += 3;
 				this.currentImage.isSmallImage = true;
 			}
@@ -124,8 +124,8 @@
 			}
 			if (this.currentImage.isSmallImage) {
 				this.zoomable.flyTo(0, 0, this.smallImageScale, true);
-			} else if ( $(window).width() < this.zoomable.width ||
-				    $(window).height() < this.zoomable.height ) {
+			} else if ($(window).width() < this.zoomable.width ||
+				$(window).height() < this.zoomable.height) {
 				// The image is larger than the window.
 				// Set minimum zoom and call flyZoomToFit.
 				this.zoomable.setMinZoom(this.zoomable.getZoomToFitValue());
@@ -151,9 +151,9 @@
 		 */
 		_detectFullscreen: function () {
 			this.canFullScreen = this.element.requestFullscreen !== undefined ||
-			this.element.mozRequestFullScreen !== undefined ||
-			this.element.webkitRequestFullscreen !== undefined ||
-			this.element.msRequestFullscreen !== undefined;
+				this.element.mozRequestFullScreen !== undefined ||
+				this.element.webkitRequestFullscreen !== undefined ||
+				this.element.msRequestFullscreen !== undefined;
 		},
 
 		/**
@@ -176,10 +176,12 @@
 		 * @private
 		 */
 		_zoomDecider: function () {
-			if (this.fullScreen === null && this.currentImage.mimeType !== 'image/svg+xml') {
-				this.zoomToOriginal();
-			} else {
-				this.zoomToFit();
+			if (this.zoomable !== null) {
+				if (this.fullScreen === null && this.currentImage.mimeType !== 'image/svg+xml') {
+					this.zoomToOriginal();
+				} else {
+					this.zoomToFit();
+				}
 			}
 		},
 
@@ -193,18 +195,18 @@
 			}
 			if (this.currentImage.isSmallImage) {
 				this.zoomable.setZoom(this.smallImageScale, true);
-			} else if ( $(window).width() < this.zoomable.width || 
-			            $(window).height() < this.zoomable.height ||
-				    this.fullScreen !== null ||
-				    this.currentImage.mimeType === 'image/svg+xml' ) {
+			} else if ($(window).width() < this.zoomable.width ||
+				$(window).height() < this.zoomable.height ||
+				this.fullScreen !== null ||
+				this.currentImage.mimeType === 'image/svg+xml') {
 				// The image is larger than the window, or we are fullScreen,
 				// or this is an SVG. Set minimum zoom and call zoomToFit.
 				this.zoomable.setMinZoom(this.zoomable.getZoomToFitValue());
 				this.zoomable.zoomToFit();
-			} else { 
+			} else {
 				// Zoom to the image size.
 				this.zoomable.setMinZoom(0);
-				this.zoomable.setZoom(0, true); 
+				this.zoomable.setZoom(0, true);
 			}
 		},
 

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -9,4 +9,5 @@
 
 	<div class="progress icon-view-pause"/>
 	<div class="notification"></div>
+	<div class="bigshotContainer"></div>
 </div>


### PR DESCRIPTION
- Back button support. Fixes #160 with the help of @setnes
- Clean up all images when closed
- Remove duplicate events
- Properly clear previous/next image
- Wait for the slideshow to be ready before trying to use it (before that it was just luck)
- Load the slideshow only when needed on the Files app
- Load the slideshow at init time in the Gallery app
- Minor fixes and JS optimisations

**This is for the most recent release of ownCloud: 8.0**

Visually, you should notice that there shouldn't be any picture overlap any more when quickly switching to the previous slide before the current one has loaded, but I doubt you'll see anything else.

Using the slideshow's close button or the browser's back button should achieve the same thing on both the Gallery and Files app. Full specs are in #160

@setnes @vader2014 @demattin @jancborchardt @PVince81 

Feel free to let me know if the JS can be better written, etc.
