### PR TITLE
make gallery/filelist switcher button less present and distracting

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -1,14 +1,15 @@
 /* toggle for opening shared picture view as file list */
 #openAsFileListButton {
 	float: right;
-	margin-right: 4px;
 	margin-top: 5px;
 	font-weight: normal;
+	background-color: transparent;
+	border: none;
 }
 
 #openAsFileListButton img {
 	vertical-align: text-top;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-	filter: alpha(opacity=50);
-	opacity: .5;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
+	filter: alpha(opacity=30);
+	opacity: .3;
 }


### PR DESCRIPTION
Removed the button style and made it a bit more transparent. As we talked about @oparoz @karlitschek @owncloud/designers 

I tried using the pictures filetype icon instead of the current icon but it looks wrong, an image icon floating there.
