### PR TITLE
remove background toggle as it was very confusing for people

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -137,11 +137,6 @@
 	top: 6px;
 }
 
-#slideshow > .changeBackground {
-	right: 135px;
-	top: 6px;
-}
-
 #slideshow > .notification {
 	margin: 0 auto;
 	max-width: 60%;

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -97,7 +97,6 @@
 			var currentImageId = index;
 			return this.loadImage(this.images[index]).then(function (img) {
 				this.container.css('background-position', '-10000px 0');
-				this.container.find('.changeBackground').show();
 
 				// check if we moved along while we were loading
 				if (currentImageId === index) {
@@ -113,8 +112,6 @@
 					img.setAttribute('alt', image.name);
 					$(img).css('position', 'absolute');
 					$(img).css('background-color', backgroundColour);
-					var $border = 30 / window.devicePixelRatio;
-					$(img).css('outline', $border + 'px solid ' + backgroundColour);
 
 					// We cannot use nice things on IE8
 					if ($('html').is('.ie8')) {
@@ -214,15 +211,12 @@
 			var container = this.zoomablePreviewContainer.children('img');
 			var rgb = container.css('background-color').match(/\d+/g);
 			var hex = "#" + toHex(rgb[0]) + toHex(rgb[1]) + toHex(rgb[2]);
-			var $border = 30 / window.devicePixelRatio;
 
 			// Grey #363636
 			if (hex === "#000000") {
 				container.css('background-color', '#FFF');
-				container.css('outline', $border + 'px solid #FFF');
 			} else {
 				container.css('background-color', '#000');
-				container.css('outline', $border + 'px solid #000');
 			}
 		},
 
@@ -239,7 +233,6 @@
 			}
 			this.container.find('.notification').html(message);
 			this.container.find('.notification').show();
-			this.container.find('.changeBackground').hide();
 		},
 
 		/**
@@ -364,11 +357,6 @@
 						{
 							el: '.downloadImage',
 							trans: t('gallery', 'Download'),
-							toolTip: true
-						},
-						{
-							el: '.changeBackground',
-							trans: t('gallery', 'Toggle background'),
 							toolTip: true
 						}
 					];

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -59,9 +59,6 @@
 			// Hide prev/next and play buttons when we only have one pic
 			this.container.find('.next, .previous, .play').toggle(this.images.length > 1);
 
-			// Hide the toggle background button until we have something to show
-			this.container.find('.changeBackground').hide();
-
 			if (autoPlay) {
 				this._play();
 			}
@@ -126,7 +123,6 @@
 		 */
 		_specialButtonSetup: function (makeCallBack) {
 			this.container.children('.downloadImage').click(makeCallBack(this._getImageDownload));
-			this.container.children('.changeBackground').click(makeCallBack(this._toggleBackground));
 		},
 
 		/**
@@ -337,15 +333,6 @@
 			var downloadUrl = this.images[this.current].downloadUrl;
 
 			return this.slideshow.getImageDownload(downloadUrl);
-		},
-
-		/**
-		 * Changes the colour of the background of the image
-		 *
-		 * @private
-		 */
-		_toggleBackground: function () {
-			this.slideshow.toggleBackground();
 		}
 
 	};

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -5,7 +5,6 @@
 	<input type="button" class="svg previous icon-view-previous"/>
 	<input type="button" class="svg exit icon-view-close"/>
 	<input type="button" class="svg downloadImage icon-view-download"/>
-	<input type="button" class="svg changeBackground icon-view-toggle-background"/>
 
 	<div class="progress icon-view-pause"/>
 	<div class="notification"></div>


### PR DESCRIPTION
Remove the background toggle button since it came up in many user tests it was very confusing. cc @karlitschek @tomneedham @oparoz 

Instead, all images should have white background by default – without border! That way we will take care of nearly all transparent pngs/svgs. We can gradually improve to also fix the corner case of transparent images with _white_ foreground.

Please review @owncloud/designers @oparoz 
