### PR TITLE
[WIP] Enable encryption in tests

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -23,6 +23,10 @@ OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 // Give access to core tests to Codeception
 Autoload::addNamespace('Test', '/../../../tests/lib');
 
+// Enable encryption
+OC_App::installApp('encryption');
+OC_App::enable('encryption');
+
 // Load all apps
 OC_App::loadApps();
 

--- a/tests/_support/Helper/DataSetup.php
+++ b/tests/_support/Helper/DataSetup.php
@@ -132,6 +132,10 @@ class DataSetup extends \Codeception\Module {
 		// Enable encryption
 		$this->server->getConfig()
 					 ->setAppValue('core', 'encryption_enabled', 'yes');
+		$this->assertTrue(\OC_App::isEnabled('encryption'));
+		$defaultModule = $this->server->getConfig()
+									  ->getAppValue('core', 'default_encryption_module', null);
+		$this->assertSame('OC_DEFAULT_MODULE',$defaultModule);
 
 		// This is because the filesystem is not properly cleaned up sometimes
 		$this->server->getAppManager()

--- a/tests/_support/Helper/DataSetup.php
+++ b/tests/_support/Helper/DataSetup.php
@@ -129,13 +129,9 @@ class DataSetup extends \Codeception\Module {
 		$this->rootFolder = $this->server->getRootFolder();
 		$this->userManager = $this->server->getUserManager();
 
-		/**
-		 * Logging hooks are missing at the moment, so we need to disable encryption
-		 *
-		 * @link https://github.com/owncloud/core/issues/18085#issuecomment-128093797
-		 */
+		// Enable encryption
 		$this->server->getConfig()
-					 ->setAppValue('core', 'encryption_enabled', 'no');
+					 ->setAppValue('core', 'encryption_enabled', 'yes');
 
 		// This is because the filesystem is not properly cleaned up sometimes
 		$this->server->getAppManager()
@@ -234,6 +230,9 @@ class DataSetup extends \Codeception\Module {
 		$this->deleteUser($userId);
 		$this->createUser($userId, $userPassword);
 
+		$this->coreTestCase->loginAsUser($userId);
+		// Does not work because of @link https://github.com/owncloud/core/issues/18085#issuecomment-128093797
+		$this->coreTestCase->logoutUser();
 		$this->coreTestCase->loginAsUser($userId);
 
 		// Create folders and files


### PR DESCRIPTION
This currently does not work because there are no (encryption) hooks attached to the login method used in tests: https://github.com/owncloud/core/issues/18085
