### PR TITLE
adjust filename size and weight in slideshow

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -164,13 +164,12 @@
 #slideshow > .name .title {
 	padding: 0px 50px;
 	text-align: center;
-	color: #FFF;
-	font-size: 18px;
-	font-weight: bold;
+	color: #fff;
+	font-size: 16px;
 	line-height: normal;
 	text-overflow: ellipsis;
-	overflow:hidden;
-	white-space:nowrap;
+	overflow: hidden;
+	white-space: nowrap;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;


### PR DESCRIPTION
Make it look more in line with ownCloud. We barely use bold styles anymore, especially because it’s not needed when it’s the only text in the view.

Please review @oparoz @owncloud/designers
