### PR TITLE
Retrieve the media type icon when loading an image fails

### DIFF
--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -132,7 +132,7 @@ function Thumbnail (fileId, square) {
 							};
 							thumb.image.onerror = function () {
 								thumb.valid = false;
-								thumb.loadingDeferred.resolve(null);
+								thumb.image.src = Thumbnails._getMimeIcon(preview.mimetype);
 							};
 
 							if (thumb.status === 200) {
@@ -140,18 +140,33 @@ function Thumbnail (fileId, square) {
 									'data:' + preview.mimetype + ';base64,' + preview.preview;
 							} else {
 								thumb.valid = false;
-								var icon = OC.MimeType.getIconUrl(preview.mimetype);
-								if (Gallery.ieVersion !== false) {
-									icon = icon.substr(0, icon.lastIndexOf(".")) + ".png";
-								}
-								thumb.image.src = icon;
+								thumb.image.src = Thumbnails._getMimeIcon(preview.mimetype);
 							}
 						}
 					});
 			}
 
 			return batch;
+		},
+
+		/**
+		 * Returns the link to the media type icon
+		 *
+		 * Modern browsers get an SVG, older ones a PNG
+		 * 
+		 * @param mimeType
+		 *
+		 * @returns {*|string}
+		 * @private
+		 */
+		_getMimeIcon: function (mimeType) {
+			var icon = OC.MimeType.getIconUrl(mimeType);
+			if (Gallery.ieVersion !== false) {
+				icon = icon.substr(0, icon.lastIndexOf(".")) + ".png";
+			}
+			return icon;
 		}
+
 	};
 
 	window.Thumbnails = Thumbnails;


### PR DESCRIPTION
Problems are usually detected on the PHP side, when trying to generate a preview, but it's not the case for SVG and there could be other problems along the road, so we fetch the media type icon in case of failure
Fixes #346
