### PR TITLE
improve touch area of slideshow controls, fix #53

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -93,16 +93,19 @@
 }
 
 #slideshow > .next, #slideshow > .previous {
-	top: 50%;
-	margin-top: -21px;
+	height: 100%;
+	top: 0;
+	margin-top: 0;
 }
-
 #slideshow > .next {
+	width: 80%;
 	right: 0;
+	background-position: right 10px center;
 }
-
 #slideshow > .previous {
+	width: 20%;
 	left: 0;
+	background-position: 10px center;
 }
 
 #slideshow > .exit {

--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -90,6 +90,7 @@
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
 	filter: alpha(opacity=75);
 	opacity: .75;
+	transition: opacity 300ms;
 }
 
 #slideshow > .next, #slideshow > .previous {

--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -46,8 +46,10 @@
 }
 
 #slideshow.inactive > input,
+#slideshow.inactive > input:hover,
 #slideshow.inactive > .progress,
 #slideshow.inactive > .menu input,
+#slideshow.inactive > .menu input:hover,
 #slideshow.inactive > .name {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
 	filter: alpha(opacity=0);


### PR DESCRIPTION
Fix https://github.com/owncloud/gallery/issues/53, please review @oparoz @owncloud/designers 

Improvements:
- »Next« button takes all space, so clicking on the image now also advances it (as with most Galleries). Because it’s first in the DOM, it will be overlayed by the other actions where they are.
- »Previous« button takes up 20% of the left side
- »Exit« and »Play/Pause« are both bigger
