### PR TITLE
New occ commands to manage thumbnails

### DIFF
--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ * @author Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * @copyright Olivier Paroz 2015
+ * @copyright Bernhard Posselt 2015
+ */
+
+use OCP\AppFramework\IAppContainer;
+
+if (\OC::$server->getConfig()
+				->getSystemValue('installed', false)
+) {
+	$galleryApp = new OCA\Gallery\AppInfo\Application();
+	$galleryContainer = $galleryApp->getContainer();
+	$galleryContainer->registerService(
+		'userFolder', function (IAppContainer $c) {
+		return null;
+	}
+	);
+	$galleryContainer->registerService(
+		'OCP\Encryption\IManager', function (IAppContainer $c) {
+		return $c->getServer()
+				 ->getEncryptionManager();
+	}
+	);
+	$galleryContainer->registerService(
+		'OCP\Files\Mount\IMountManager', function (IAppContainer $c) {
+		return $c->getServer()
+				 ->getMountManager();
+	}
+	);
+	$galleryContainer->registerService(
+		'OCP\Lock\ILockingProvider', function (IAppContainer $c) {
+		return $c->getServer()
+				 ->getLockingProvider();
+	}
+	);
+
+	$createThumbnailsCmd = $galleryContainer->query('OCA\Gallery\Command\CreateThumbnails');
+	$deleteThumbnailsCmd = $galleryContainer->query('OCA\Gallery\Command\DeleteThumbnails');
+
+	$application->add($createThumbnailsCmd);
+	$application->add($deleteThumbnailsCmd);
+}

--- a/command/commandexception.php
+++ b/command/commandexception.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+/**
+ * Thrown when the command is not authorised to access a file
+ */
+class CommandException extends \Exception {}

--- a/command/createthumbnails.php
+++ b/command/createthumbnails.php
@@ -1,0 +1,461 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// Does not exist in OCP
+use OC\Files\Cache\ChangePropagator;
+use OC\Files\Storage\Storage;
+// Does not exist in OCP and needed by ChangePropagator
+use OC\Files\View;
+// Methods we need are not available in OCP
+use OC\Preview;
+
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\IUser;
+use OCP\Files\IRootFolder;
+// 8.2+ only
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Encryption\IManager;
+use OCP\Lock\ILockingProvider;
+
+use OCA\Gallery\Service\ConfigService;
+
+/**
+ * Class CreateThumbnails
+ *
+ * Creates missing thumbnails of visual media types supported by the system
+ *
+ * @package OCA\Gallery\Command
+ */
+class CreateThumbnails extends Thumbnails {
+
+	/** @var GalleryScanner */
+	private $scanner;
+	/** @var IManager */
+	private $encryptionManager;
+	/** @var ChangePropagator */
+	private $propagator;
+	/** @var int */
+	private $thumbnailWidth = 400;
+	/** @var int */
+	private $thumbnailHeight = 200;
+	/** @var bool */
+	private $regenerate = false;
+
+	/**
+	 * Constructor
+	 *
+	 * @param IDBConnection $database
+	 * @param IUserManager $userManager
+	 * @param IRootFolder $rootFolder
+	 * @param IMountManager $mountManager
+	 * @param ConfigService $configService
+	 * @param IManager $encryptionManager
+	 * @param ILockingProvider $lockingProvider
+	 */
+	public function __construct(
+		IDBConnection $database,
+		IUserManager $userManager,
+		IRootFolder $rootFolder,
+		IMountManager $mountManager,
+		ConfigService $configService,
+		IManager $encryptionManager,
+		ILockingProvider $lockingProvider
+	) {
+		$this->encryptionManager = $encryptionManager;
+		$this->propagator = new ChangePropagator(new View(''));
+		$this->scanner = new GalleryScanner($database, $this->propagator, $lockingProvider);
+
+		parent::__construct($userManager, $rootFolder, $mountManager, $configService);
+	}
+
+	/**
+	 * Generates a thumbnail if there isn't one in the cache yet
+	 *
+	 * The first step is to make sure the path we've received is within the folder we're scanning
+	 * since events are fired every time a file is scanned
+	 *
+	 * @param string $path
+	 * @param IMountPoint $mount
+	 * @param string $user
+	 * @param OutputInterface $output
+	 */
+	public function generateMissingThumbnail(
+		$path, IMountPoint $mount, $user, OutputInterface $output
+	) {
+		$path = $mount->getMountPoint() . $path;
+		$pathFolders = $this->isPathAllowed($user, $path);
+		$cancelled = $this->hasBeenInterrupted();
+		if ($pathFolders && !$cancelled) {
+			$newFolders = array_slice($pathFolders, 3);
+			$pathFromVirtualRoot = ltrim(implode('/', $newFolders), '/');
+			// Make sure we really have a file
+			/** @type File|Folder $node */
+			$node = $this->rootFolder->get($path);
+			if ($this->isFile($node)) {
+				$this->filesCounter++;
+				$this->lastFile = $node->getPath();
+				$this->createThumbnailForSupportedMediaType(
+					$user, $node, $path, $pathFromVirtualRoot, $output
+				);
+			}
+		}
+	}
+
+	/**
+	 * Adds one to the total count of scanned folders
+	 *
+	 * @param string $path
+	 * @param \OC\Files\Mount\MountPoint $mount
+	 * @param string $user
+	 * @param OutputInterface $output
+	 */
+	public function countFolders($path, IMountPoint $mount, $user, OutputInterface $output
+	) {
+		$path = $mount->getMountPoint() . $path;
+		if ($this->isPathAllowed($user, $path)) {
+			$this->foldersCounter++;
+		}
+	}
+
+	/**
+	 * Configures the command and describes parameters
+	 */
+	protected function configure() {
+		$this->setName('gallery:create-thumbnails')
+			 ->setDescription('creates thumbnails for supported visual media files')
+			 ->addArgument(
+				 'user_id',
+				 InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				 'will rescan all files of the given user(s) located in the files folder and create thumbnails of visual media files'
+			 )
+			 ->addOption(
+				 'path',
+				 'p',
+				 InputArgument::OPTIONAL,
+				 'limit rescan to this path, eg. --path="/alice/files/Holidays", the user_id is determined by the path and the user_id parameter and --all are ignored'
+			 )
+			 ->addOption(
+				 'quiet',
+				 'q',
+				 InputOption::VALUE_NONE,
+				 'suppress output'
+			 )
+			 ->addOption(
+				 'regenerate',
+				 'r',
+				 InputOption::VALUE_NONE,
+				 'forces the re-generation of thumbnails'
+			 )
+			 ->addOption(
+				 'all',
+				 null,
+				 InputOption::VALUE_NONE,
+				 'will rescan all files folders of all known users and create thumbnails of visual media files'
+			 );
+	}
+
+	/**
+	 * Executes the current command.
+	 *
+	 * This method is not abstract because you can use this class
+	 * as a concrete class. In this case, instead of defining the
+	 * execute() method, you set the code to execute by passing
+	 * a Closure to the setCode() method.
+	 *
+	 * @param InputInterface $input An InputInterface instance
+	 * @param OutputInterface $output An OutputInterface instance
+	 *
+	 * @return int|null null or 0 if everything went fine, or an error code
+	 *
+	 * @throws \Exception
+	 * @see    setCode()
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ($this->encryptionManager->isEnabled() === true) {
+			throw new ForbiddenCommandException(
+				'We cannot create thumbnails if server side encryption is enabled'
+			);
+		}
+
+		$this->initTools();
+
+		$userInputErrorMsg =
+			"Please specify the user id to scan, \"--all\" to scan for all users or \"--path=...\"";
+		$pathInputErrorMsg =
+			"The path given in \"--path=...\" does not start with \"/user_id/files\" eg. --path=\"/alice/files/Holidays\"";
+		try {
+			list($inputPath, $users, $regenerate) =
+				$this->parseParameters($input, $userInputErrorMsg, $pathInputErrorMsg, $output);
+		} catch (CommandException $exception) {
+			$message = $exception->getMessage();
+			$output->writeln("<error>$message</error>");
+
+			return;
+		}
+
+		$this->regenerate = $regenerate;
+
+		$this->scanAndGenerateMissingThumbnails($users, $inputPath, $output);
+
+		$this->presentResults($output);
+	}
+
+	/**
+	 * @inherit
+	 */
+	protected function parseParameters(
+		InputInterface $input, $userInputErrorMsg, $pathInputErrorMsg, OutputInterface $output
+	) {
+		$params = parent::parseParameters($input, $userInputErrorMsg, $pathInputErrorMsg, $output);
+
+		return array_merge($params, [$input->getOption('regenerate')]);
+	}
+
+	/**
+	 * @inherit
+	 */
+	protected function presentResults(OutputInterface $output) {
+		parent::presentResults($output);
+		$headers = [
+			'Folders', 'Files', 'Supported images', 'New previews', 'Failed previews',
+			'Elapsed time',
+			'Total size'
+		];
+
+		if ($this->filesCounter > 0) {
+			$this->showSummary($headers, null, $output);
+		}
+
+		$headers = ['List of failed previews'];
+		$this->showFailed($headers, $output);
+	}
+
+	/**
+	 * Scans a given user's specific mounted storage and updates the cache
+	 *
+	 * @param Storage $storage
+	 * @param IMountPoint $mount
+	 * @param string $path
+	 * @param string $user
+	 * @param OutputInterface $output
+	 *
+	 * @return array
+	 * @see OC\Files\Utils\Scanner::scan
+	 */
+	protected function scanAndUpdateCache(
+		$storage, IMountPoint $mount, $path, $user, OutputInterface $output
+	) {
+		$size = $this->scanner->scan(
+			$storage,
+			$mount,
+			$path,
+			$user,
+			[$this, 'generateMissingThumbnail'],
+			[$this, 'countFolders'],
+			$output
+		);
+
+		return $size;
+	}
+
+	/**
+	 * Scans and generates missing thumbnails for all given users
+	 *
+	 * @param IUser[]|string[] $users
+	 * @param string $inputPath
+	 * @param OutputInterface $output
+	 */
+	private function scanAndGenerateMissingThumbnails($users, $inputPath, OutputInterface $output) {
+		foreach ($users as $user) {
+			if (is_object($user)) {
+				$user = $user->getUID();
+			}
+			// Only create thumbnails for files located in the user's "files" folder
+			$path = $inputPath ? $inputPath : '/' . $user . '/files';
+			if ($this->userManager->userExists($user)) {
+				$this->scanForMissingThumbnails($user, $path, $output);
+			} else {
+				$output->writeln("<error>Unknown user $user</error>");
+			}
+		}
+	}
+
+	/**
+	 * Scans a given user's filesystem
+	 *
+	 * Discovered files are received via listeners which will then generate the thumbnails
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param OutputInterface $output
+	 */
+	private function scanForMissingThumbnails(
+		$user, $path, OutputInterface $output
+	) {
+		try {
+			$foldersMetaData =
+				$this->performOperation(
+					'scanAndUpdateCache', $user, $path, $output
+				);
+
+			// Propagates the changes to all parent folder
+			$this->propagator->propagateChanges(time());
+			foreach ($foldersMetaData as $metaData) {
+				$this->folderSize += $metaData['size'];
+			}
+		} catch (CommandException $exception) {
+			$message = $exception->getMessage();
+			$output->writeln("<error>$message</error>");
+		}
+	}
+
+	/**
+	 * Makes sure we only create thumbnails for files located in the user's "files" folder
+	 *
+	 * This check is still needed here because events we listen to can return newly created
+	 * thumbnails!
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return array|bool
+	 */
+	private function isPathAllowed($user, $path) {
+		$folders = explode('/', $path);
+		if ($folders[1] === $user && $folders[2] === 'files') {
+			return $folders;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Creates a new thumbnail if it's missing
+	 *
+	 * This creates both the preview of max size and the thumbnail shown in the Gallery's photowall
+	 *
+	 * @param string $user owner of the Files
+	 * @param File $file
+	 * @param string $path full path to the file from the data folder
+	 * @param string $pathFromVirtualRoot relative path, without <user>/files/
+	 * @param OutputInterface $output
+	 */
+	private function createThumbnailForSupportedMediaType(
+		$user, File $file, $path, $pathFromVirtualRoot, OutputInterface $output
+	) {
+		try {
+			$fileId = $file->getId();
+			$this->printToConsole("Analysing <info>[ID: $fileId] $path</info>...", $output);
+			$mediaType = $file->getMimeType();
+			if (in_array($mediaType, $this->supportedMediaTypes)) {
+				$this->imagesCounter++;
+				$preview = new Preview($user, 'files', $pathFromVirtualRoot);
+				$this->checkCacheAndCreateThumbnail(
+					$fileId, $preview, $path, $output
+				);
+			} else {
+				$this->printToConsole("There is no preview provider for that media type", $output);
+			}
+		} catch (\Exception $exception) {
+			$output->writeln("<error>Problem accessing $path</error>");
+		}
+	}
+
+	/**
+	 * Creates a new thumbnail if it's missing
+	 *
+	 * This creates both the preview of max size and the thumbnail shown in the Gallery's photowall
+	 *
+	 * @param int $fileId
+	 * @param Preview $preview
+	 * @param string $path full path to the file from the data folder
+	 * @param OutputInterface $output
+	 *
+	 * @internal param string $user owner of the Files
+	 */
+	private function checkCacheAndCreateThumbnail(
+		$fileId, Preview $preview, $path, OutputInterface $output
+	) {
+		$isCached = $preview->isCached($fileId);
+		if ($isCached && !$this->regenerate) {
+			$this->printToConsole(
+				"The system already has a preview for that file", $output
+			);
+		} else {
+			if ($this->regenerate) {
+				$this->printToConsole(
+					"Forcing the regeneration of the preview...", $output
+				);
+				$preview->deleteAllPreviews();
+			} else {
+				$this->printToConsole(
+					"The scanner has found a missing preview! Generating...", $output
+				);
+			}
+			$this->CreateThumbnail($preview, $path, $output);
+		}
+	}
+
+	/**
+	 * Creates a new thumbnail if it's missing
+	 *
+	 * This creates both the preview of max size and the thumbnail shown in the Gallery's photowall
+	 *
+	 * @param Preview $preview
+	 * @param string $path full path to the file from the data folder
+	 * @param OutputInterface $output
+	 *
+	 * @internal param string $user owner of the Files
+	 */
+	private function CreateThumbnail(Preview $preview, $path, OutputInterface $output) {
+		try {
+			$preview->setMaxX($this->thumbnailWidth);
+			$preview->setMaxY($this->thumbnailHeight);
+			$preview->setKeepAspect(true);
+			$preview->getPreview();
+			if ($preview) {
+				$this->operationCounter++;
+				$this->printToConsole("Preview generated!", $output);
+			} else {
+				$this->trackFailedOperation(
+					$path, "The system was unable to generate a preview", $output
+				);
+			}
+		} catch (\Exception $exception) {
+			$extra = $exception->getMessage();
+			$this->trackFailedOperation(
+				$path, "There was an unexpected error while trying to generate the preview. $extra",
+				$output
+			);
+		}
+	}
+
+}

--- a/command/deletethumbnails.php
+++ b/command/deletethumbnails.php
@@ -1,0 +1,423 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+
+use OC\Files\Storage\Storage;
+
+use OCP\IUser;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Mount\IMountPoint;
+
+/**
+ * Class DeleteThumbnails
+ *
+ * Deletes thumbnails of visual media types stored in the system
+ *
+ * @package OCA\Gallery\Command
+ */
+class DeleteThumbnails extends Thumbnails {
+
+	const THUMBNAILS_FOLDER = 'thumbnails';
+
+	/**
+	 * Configures the command and describes parameters
+	 */
+	protected function configure() {
+		$this->setName('gallery:delete-thumbnails')
+			 ->setDescription('deletes thumbnails of supported visual media files')
+			 ->addArgument(
+				 'user_id',
+				 InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				 'will delete all thumbnails of visual media files for the given user(s)'
+			 )
+			 ->addOption(
+				 'path',
+				 'p',
+				 InputArgument::OPTIONAL,
+				 'limit scope to this path, eg. --path="/alice/files/Holidays", the user_id is determined by the path and the user_id parameter and --all are ignored'
+			 )
+			 ->addOption(
+				 'quiet',
+				 'q',
+				 InputOption::VALUE_NONE,
+				 'suppress output'
+			 )
+			 ->addOption(
+				 'cache',
+				 'c',
+				 InputOption::VALUE_NONE,
+				 'clear cache only'
+			 )
+			 ->addOption(
+				 'all',
+				 null,
+				 InputOption::VALUE_NONE,
+				 'will delete all thumbnails of visual media files'
+			 );
+	}
+
+	/**
+	 * Executes the current command.
+	 *
+	 * This method is not abstract because you can use this class
+	 * as a concrete class. In this case, instead of defining the
+	 * execute() method, you set the code to execute by passing
+	 * a Closure to the setCode() method.
+	 *
+	 * @param InputInterface $input An InputInterface instance
+	 * @param OutputInterface $output An OutputInterface instance
+	 *
+	 * @return int|null null or 0 if everything went fine, or an error code
+	 *
+	 * @throws \Exception
+	 * @see    setCode()
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->initTools();
+
+		$userInputErrorMsg =
+			"Please specify a user id, \"--all\" to delete all thumbnails or \"--path=...\"";
+		$pathInputErrorMsg =
+			"The path given in \"--path=...\" does not start with \"/user_id/files\" or does not exist";
+		try {
+			list($inputPath, $users, $clearCacheOnly) =
+				$this->parseParameters($input, $userInputErrorMsg, $pathInputErrorMsg, $output);
+			$this->confirmAction($users, $inputPath, $input, $output);
+		} catch (CommandException $exception) {
+			$message = $exception->getMessage();
+			$output->writeln("<error>$message</error>");
+
+			return;
+		}
+
+		$this->deleteThumbnailsForUsersOrPath($users, $inputPath, $clearCacheOnly, $output);
+
+		$this->presentResults($output);
+	}
+
+	/**
+	 * @inherit
+	 */
+	protected function parseParameters(
+		InputInterface $input, $userInputErrorMsg, $pathInputErrorMsg, OutputInterface $output
+	) {
+		$params = parent::parseParameters($input, $userInputErrorMsg, $pathInputErrorMsg, $output);
+
+		return array_merge($params, [$input->getOption('cache')]);
+	}
+
+	/**
+	 * @inherit
+	 */
+	protected function presentResults(OutputInterface $output) {
+		parent::presentResults($output);
+
+		if ($this->imagesCounter > 0) {
+			$niceDate = $this->formatExecTime();
+			$size = $this->formatSize($this->folderSize);
+			$headers = [
+				'Images found', 'Deleted thumbnails', 'Failed deletion', 'Elapsed time',
+				'Space saved'
+			];
+			$rows = [
+				$this->imagesCounter,
+				$this->operationCounter,
+				$this->failedOperationCounter,
+				$niceDate,
+				$size
+			];
+
+			$this->showSummary($headers, $rows, $output);
+
+			$headers = ['List of failed deletions'];
+			$this->showFailed($headers, $output);
+		}
+
+	}
+
+	/**
+	 * Scans a given user's filesystem and return all Ids of images
+	 *
+	 * @param Storage $storage
+	 * @param IMountPoint $mount
+	 * @param string $path
+	 * @param string $user
+	 * @param OutputInterface $output
+	 *
+	 * @return array
+	 * @throws NotFoundCommandException
+	 * @see OC\Files\Utils\Scanner::scan
+	 */
+	protected function getAllFileIds(
+		$storage, IMountPoint $mount, $path, $user, OutputInterface $output
+	) {
+		/** @type Folder $thumbnailsFolder */
+		$thumbnailsFolder = $this->getNode($path);
+		if (!$thumbnailsFolder) {
+			throw new NotFoundCommandException("The path provided is invalid");
+		}
+		foreach ($this->supportedMediaTypes as $mediaType) {
+			/** @type File[] $images */
+			// Does not work properly with external shares
+			// https://github.com/owncloud/core/issues/19544
+			$images = $thumbnailsFolder->searchByMime($mediaType);
+			if ($images) {
+				$output->writeln("<info>Found images of media type $mediaType</info>");
+				$this->findAndDeleteThumbnails($user, $images, $output);
+			}
+		}
+	}
+
+	/**
+	 * Makes sure the users really understand what is going to happen
+	 *
+	 * @param IUser[]|string[] $users
+	 * @param string $inputPath
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @throws InputCommandException
+	 */
+	private function confirmAction(
+		$users, $inputPath, InputInterface $input, OutputInterface $output
+	) {
+		if ($inputPath) {
+			$this->getConfirmation(
+				$input,
+				"<question>Are you sure you want to delete the thumbnails for files in this path: $inputPath?</question>",
+				$output
+			);
+		} else if ($users === $this->userManager->search('')) {
+			$this->getConfirmation(
+				$input,
+				'<question>Are you sure you want to delete the thumbnails for all users?</question>',
+				$output
+			);
+		} else {
+			$userList = implode(',', $users);
+			$this->getConfirmation(
+				$input,
+				"<question>Are you sure you want to delete the thumbnails for $userList?</question>",
+				$output
+			);
+		}
+	}
+
+	/**
+	 * Deletes thumbnails for all given users or for files belonging to a specific path
+	 *
+	 * @param IUser[]|string[] $users
+	 * @param string $inputPath
+	 * @param OutputInterface $output
+	 */
+	private function deleteThumbnailsForUsersOrPath(
+		$users, $inputPath, $clearCacheOnly, OutputInterface $output
+	) {
+		foreach ($users as $user) {
+			if (is_object($user)) {
+				$user = $user->getUID();
+			}
+			if ($this->userManager->userExists($user)) {
+				if ($inputPath) {
+					$this->deleteThumbnailsForPath($user, $inputPath, $output);
+				} else {
+					$this->deleteThumbnailsForUser($user, $clearCacheOnly, $output);
+				}
+			} else {
+				$output->writeln("<error>Unknown user $user</error>");
+			}
+		}
+	}
+
+	/**
+	 * Deletes all thumbnails linked to files belonging to a specific path
+	 *
+	 * @param string $user
+	 * @param string $inputPath
+	 * @param OutputInterface $output
+	 */
+	private function deleteThumbnailsForPath($user, $inputPath, OutputInterface $output) {
+		try {
+			$this->performOperation('getAllFileIds', $user, $inputPath, $output);
+		} catch (CommandException $exception) {
+			$message = $exception->getMessage();
+			$output->writeln("<error>$message</error>");
+		}
+	}
+
+	/**
+	 * Deletes all thumbnails for a user
+	 *
+	 * @param string $user
+	 * @param bool $clearCacheOnly
+	 * @param OutputInterface $output
+	 */
+	private function deleteThumbnailsForUser($user, $clearCacheOnly, OutputInterface $output) {
+		try {
+			// Has to be called before any filesystem or caching operation
+			\OC_Util::tearDownFS();
+			\OC_Util::setupFS($user);
+
+			if ($clearCacheOnly) {
+				$this->clearCacheForThumbnails($user, $output);
+			} else {
+				$this->deleteThumbnailsFolder($user, $output);
+			}
+		} catch (\OCP\Files\NotFoundException $exception) {
+			$extra = $exception->getMessage();
+			$output->writeln(
+				"<error>Cannot delete the thumbnails folder for $user. $extra</error>"
+			);
+			$output->writeln(
+				"Make sure you're running the scan command only as the user the web server runs as"
+			);
+		}
+	}
+
+	/**
+	 * Deletes all thumbnails for a user
+	 *
+	 * @param string $user
+	 * @param OutputInterface $output
+	 */
+	private function clearCacheForThumbnails($user, OutputInterface $output) {
+		$output->writeln("<info>Removing all thumbnails for $user, from the cache</info>");
+
+		$mount = $this->rootFolder->get('/' . $user);
+		/** @type Storage $storage */
+		$storage = $mount->getStorage();
+		$cache = $storage->getCache('');
+		$cache->remove(self::THUMBNAILS_FOLDER);
+	}
+
+	/**
+	 * Deletes all thumbnails linked to a media file
+	 *
+	 * @param string $user owner of the Files
+	 * @param OutputInterface $output
+	 *
+	 * @internal param \OCP\Files\File[] $images
+	 */
+	private function deleteThumbnailsFolder($user, OutputInterface $output) {
+		$relativePath = self::THUMBNAILS_FOLDER;
+		$successMessage = "<info>Deleted all thumbnails for $user</info>";
+		$errorMessage = "<info>No thumbnails found for $user</info>";
+		list($result, $imagesCount) =
+			$this->deleteThumbnails(
+				$user, $relativePath, $successMessage, $errorMessage, $output
+			);
+		if ($result) {
+			$this->imagesCounter = $imagesCount;
+			$this->operationCounter = $imagesCount;
+		}
+	}
+
+	/**
+	 * Finds and deletes all thumbnails linked to a media file
+	 *
+	 * @param string $user owner of the Files
+	 * @param File[] $images
+	 * @param OutputInterface $output
+	 */
+	private function findAndDeleteThumbnails($user, $images, OutputInterface $output) {
+		$fullPath = 'Unknown';
+		foreach ($images as $image) {
+			$cancelled = $this->hasBeenInterrupted();
+			if (!$cancelled) {
+				try {
+					$this->imagesCounter++;
+					$fileId = $image->getId();
+					$fullPath = $image->getPath();
+					$this->lastFile = $fullPath;
+					$this->deleteThumbnailsForFile($user, $fileId, $fullPath, $output);
+				} catch (\Exception $exception) {
+					$this->trackFailedOperation(
+						$fullPath,
+						'There was an unexpected error while trying to delete the thumbnails',
+						$output
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Delete the thumbnails for a specific file
+	 *
+	 * @param string $user owner of the Files
+	 * @param int $fileId
+	 * @param string $fullPath
+	 * @param OutputInterface $output
+	 */
+	private function deleteThumbnailsForFile($user, $fileId, $fullPath, OutputInterface $output) {
+		$relativePath = self::THUMBNAILS_FOLDER . '/' . $fileId;
+		$successMessage = "Thumbnails for <info>[ID: $fileId] $fullPath</info> deleted!";
+		$errorMessage = "No thumbnails found for <info>[ID: $fileId] $fullPath</info>";
+		list($result) =
+			$this->deleteThumbnails(
+				$user, $relativePath, $successMessage, $errorMessage, $output
+			);
+		if ($result) {
+			$this->operationCounter++;
+		}
+	}
+
+	/**
+	 * Delete a  thumbnails folder
+	 *
+	 * Could be the folder linked to a single ID or the whole thumbnails folder
+	 *
+	 * @param string $user owner of the Files
+	 * @param string $relativePath
+	 * @param string $successMessage
+	 * @param string $errorMessage
+	 * @param OutputInterface $output
+	 *
+	 * @return array <bool,int>
+	 */
+	private function deleteThumbnails(
+		$user, $relativePath, $successMessage, $errorMessage, OutputInterface $output
+	) {
+		$success = false;
+		$imagesCount = 0;
+		/** @type Folder $ThumbnailsFolder */
+		$ThumbnailsFolder = $this->getNode($relativePath, $user);
+		if ($ThumbnailsFolder) {
+			$this->folderSize += $ThumbnailsFolder->getSize();
+			$imagesCount = count($ThumbnailsFolder->getDirectoryListing());
+			$ThumbnailsFolder->delete();
+			$this->printToConsole($successMessage, $output);
+			$success = true;
+		} else {
+			$this->printToConsole($errorMessage, $output);
+		}
+
+		return [$success, $imagesCount];
+	}
+
+}

--- a/command/forbiddencommandexception.php
+++ b/command/forbiddencommandexception.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+/**
+ * Thrown when the command is not authorised to access a file
+ */
+class ForbiddenCommandException extends CommandException {}

--- a/command/galleryscanner.php
+++ b/command/galleryscanner.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+// Does not exist in OCP
+use OC\Files\Cache\ChangePropagator;
+// Does not exist in OCP
+use OC\Files\Cache\Scanner;
+// Static methods needed are not available in OCP
+use OC\Files\Filesystem;
+use OC\Files\Storage\Storage;
+// 8.2+ only
+use OC\Lock\DBLockingProvider;
+
+use OCP\IDBConnection;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Lock\ILockingProvider;
+
+/**
+ * Class GalleryScanner
+ *
+ * Scans a given path and calls back post scanning methods
+ *
+ * @package OCA\Gallery\Command
+ */
+class GalleryScanner {
+
+	/** @var IDBConnection */
+	private $database;
+	/** @var ChangePropagator */
+	private $propagator;
+	/** @var ILockingProvider */
+	private $lockingProvider;
+
+	/**
+	 * Constructor
+	 *
+	 * @param IDBConnection $database
+	 * @param ChangePropagator $propagator
+	 * @param ILockingProvider $lockingProvider
+	 */
+	public function __construct(
+		IDBConnection $database,
+		ChangePropagator $propagator,
+		ILockingProvider $lockingProvider
+	) {
+		$this->database = $database;
+		$this->propagator = $propagator;
+		$this->lockingProvider = $lockingProvider;
+	}
+
+	/**
+	 * Scans a given user's specific mounted storage and updates the cache
+	 *
+	 * @param Storage $storage the storage location to scan
+	 * @param IMountPoint $mount
+	 * @param string $path
+	 * @param string $user
+	 * @param Callable $fileCallback the method to call after a file has been cached
+	 * @param Callable $folderCallback the method to call after a folder has been cached
+	 * @param OutputInterface $output
+	 *
+	 * @return array
+	 * @see OC\Files\Utils\Scanner::scan
+	 */
+	public function scan(
+		Storage $storage,
+		IMountPoint $mount,
+		$path, $user,
+		Callable $fileCallback,
+		Callable $folderCallback,
+		OutputInterface $output
+	) {
+		$relativePath = $mount->getInternalPath($path);
+		$scanner = $storage->getScanner();
+		$scanner->setUseTransactions(false);
+		$this->attachListener(
+			$mount, $user, $fileCallback, $folderCallback, $output
+		);
+		$isDbLocking = $this->lockingProvider instanceof DBLockingProvider;
+		if (!$isDbLocking) {
+			$this->database->beginTransaction();
+		}
+		$size = $scanner->scan(
+			$relativePath,
+			\OC\Files\Cache\Scanner::SCAN_RECURSIVE,
+			\OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE
+		);
+		if (!$isDbLocking) {
+			$this->database->commit();
+		}
+
+		return $size;
+	}
+
+	/**
+	 * Attaches the callbacks to the storage's scanner postScanFile and postScanFolder events
+	 *
+	 * @param IMountPoint $mount
+	 * @param string $user
+	 * @param Callable $fileCallback
+	 * @param Callable $folderCallback
+	 * @param OutputInterface $output
+	 *
+	 * @see OC\Files\Utils\Scanner::attachListener
+	 */
+	private function attachListener(
+		IMountPoint $mount,
+		$user,
+		Callable $fileCallback,
+		Callable $folderCallback,
+		OutputInterface $output
+	) {
+		$scanner = $mount->getStorage()
+						 ->getScanner();
+		$scanner->listen(
+			'\OC\Files\Cache\Scanner', 'postScanFile',
+			function ($path) use ($fileCallback, $mount, $user, $output) {
+				call_user_func_array(
+					$fileCallback, [$path, $mount, $user, $output]
+				);
+			}
+		);
+		$scanner->listen(
+			'\OC\Files\Cache\Scanner', 'postScanFolder',
+			function ($path) use ($folderCallback, $mount, $user, $output) {
+				call_user_func_array(
+					$folderCallback, [$path, $mount, $user, $output]
+				);
+			}
+		);
+		$this->addChangesToPropagator($scanner, $mount);
+	}
+
+	/**
+	 * Collects cache changes
+	 *
+	 * Listens to addToCache and removeFromCache events
+	 *
+	 * @param Scanner $scanner
+	 * @param IMountPoint $mount
+	 */
+	private function addChangesToPropagator(Scanner $scanner, IMountPoint $mount) {
+		// Propagate etag and mtimes when files are changed or removed
+		$propagator = $this->propagator;
+		$propagatorListener = function ($path) use ($mount, $propagator) {
+			$fullPath = Filesystem::normalizePath($mount->getMountPoint() . $path);
+			$propagator->addChange($fullPath);
+		};
+		$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', $propagatorListener);
+		$scanner->listen('\OC\Files\Cache\Scanner', 'removeFromCache', $propagatorListener);
+	}
+
+}

--- a/command/inputcommandexception.php
+++ b/command/inputcommandexception.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+/**
+ * Thrown when the command is not authorised to access a file
+ */
+class InputCommandException extends CommandException {}

--- a/command/notfoundcommandexception.php
+++ b/command/notfoundcommandexception.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+/**
+ * Thrown when the command can't find a file or folder
+ */
+class NotFoundCommandException extends CommandException {}

--- a/command/thumbnails.php
+++ b/command/thumbnails.php
@@ -1,0 +1,473 @@
+<?php
+/**
+ * ownCloud - gallery
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Olivier Paroz 2015
+ */
+
+namespace OCA\Gallery\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+// Static methods needed are not available in OCP
+use OC\Files\Filesystem;
+
+use OCP\IUserManager;
+use OCP\IUser;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node;
+
+use OCA\Gallery\Service\ConfigService;
+
+/**
+ * Class Thumbnails
+ *
+ * Manages thumbnails of visual media types supported by the system
+ *
+ * @package OCA\Gallery\Command
+ */
+abstract class Thumbnails extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+	/** @var IRootFolder */
+	protected $rootFolder;
+	/** @var IMountManager */
+	protected $mountManager;
+	/** @var ConfigService */
+	protected $configService;
+	/** @var array */
+	protected $supportedMediaTypes;
+	/** @var float */
+	protected $execTime = 0;
+	/** @var int */
+	protected $folderSize = 0;
+	/** @var int */
+	protected $foldersCounter = 0;
+	/** @var int */
+	protected $filesCounter = 0;
+	/** @var int */
+	protected $imagesCounter = 0;
+	/** @var string */
+	protected $lastFile = '';
+	/** @var string */
+	protected $lastFolder = '';
+	/** @var int */
+	protected $operationCounter = 0;
+	/** @var int */
+	protected $failedOperationCounter = 0;
+	/** @var array */
+	protected $failedOperations;
+	/** @var bool */
+	protected $interrupted = false;
+
+	/**
+	 * Constructor
+	 *
+	 * @param IUserManager $userManager
+	 * @param IRootFolder $rootFolder
+	 * @param IMountManager $mountManager
+	 * @param ConfigService $configService
+	 */
+	public function __construct(
+		IUserManager $userManager,
+		IRootFolder $rootFolder,
+		IMountManager $mountManager,
+		ConfigService $configService
+	) {
+		$this->userManager = $userManager;
+		$this->rootFolder = $rootFolder;
+		// IMountManager is 8.2+ only
+		$this->mountManager = $mountManager;
+		$this->configService = $configService;
+		// We want all the media types supported via providers only
+		$this->supportedMediaTypes = $this->configService->getSupportedMediaTypes(true, false);
+
+		parent::__construct();
+	}
+
+	/**
+	 * Processes PHP errors as exceptions in order to be able to keep track of problems
+	 *
+	 * @see https://secure.php.net/manual/en/function.set-error-handler.php
+	 *
+	 * @param int $severity the level of the error raised
+	 * @param string $message
+	 * @param string $file the filename that the error was raised in
+	 * @param int $line the line number the error was raised
+	 *
+	 * @throws \ErrorException
+	 */
+	public function exceptionErrorHandler($severity, $message, $file, $line) {
+		if (!(error_reporting() & $severity)) {
+			// This error code is not included in error_reporting
+			return;
+		}
+		throw new \ErrorException($message, 0, $severity, $file, $line);
+	}
+
+	/**
+	 * Initialises some useful tools for the Command
+	 */
+	protected function initTools() {
+		// Start the timer
+		$this->execTime = -microtime(true);
+
+		// Convert PHP errors to exceptions
+		set_error_handler([$this, 'exceptionErrorHandler'], E_ALL);
+
+		// Collect interrupts and notify the running command
+		pcntl_signal(SIGTERM, [$this, 'cancelOperation']);
+		pcntl_signal(SIGINT, [$this, 'cancelOperation']);
+	}
+
+	/**
+	 * Parses all the parameters submitted by the command user
+	 *
+	 * @param InputInterface $input
+	 * @param string $userInputErrorMsg
+	 * @param string $pathInputErrorMsg
+	 * @param OutputInterface $output
+	 *
+	 * @return array
+	 * @throws InputCommandException
+	 */
+	protected function parseParameters(
+		InputInterface $input, $userInputErrorMsg, $pathInputErrorMsg, OutputInterface $output
+	) {
+		$inputPath = $input->getOption('path');
+		if ($inputPath) {
+			$inputPath = '/' . trim($inputPath, '/');
+			try {
+				list (, $user, $topFolder) = explode('/', $inputPath, 4);
+				$users = [$user];
+			} catch (\ErrorException $exception) {
+				throw new InputCommandException($pathInputErrorMsg);
+			}
+			$this->checkPathParameter($topFolder, $pathInputErrorMsg);
+		} else if ($input->getOption('all')) {
+			$users = $this->userManager->search('');
+		} else {
+			$users = $input->getArgument('user_id');
+		}
+		$this->checkUserParameter($users, $userInputErrorMsg);
+
+		return [$inputPath, $users];
+	}
+
+	/**
+	 * Presents the results of the operation in tabular form
+	 *
+	 * @param OutputInterface $output
+	 */
+	protected function presentResults(OutputInterface $output) {
+		// Stop the timer
+		$this->execTime += microtime(true);
+
+		$output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+		$output->writeln("");
+	}
+
+	/**
+	 * Formats microtime into a human readable format
+	 *
+	 * @return string
+	 */
+	protected function formatExecTime() {
+		list($secs, $tens) = explode('.', sprintf("%.1f", ($this->execTime)));
+		$niceDate = date('H:i:s', $secs) . '.' . $tens;
+
+		return $niceDate;
+	}
+
+	/**
+	 * Formats bytes into a human readable format
+	 *
+	 * @param int $bytes
+	 * @param int $decimals
+	 *
+	 * @return string
+	 * @see https://secure.php.net/manual/en/function.filesize.php#106569
+	 */
+	protected function formatSize($bytes, $decimals = 2) {
+		$size = 'BKMGTP';
+		$factor = floor((strlen($bytes) - 1) / 3);
+
+		return sprintf("%.{$decimals}f", $bytes / pow(1024, $factor)) . @$size[$factor];
+	}
+
+	/**
+	 * Shows a summary of operations
+	 *
+	 * @param string[] $headers
+	 * @param string[] $rows
+	 * @param OutputInterface $output
+	 */
+	protected function showSummary($headers, $rows, OutputInterface $output) {
+		$niceDate = $this->formatExecTime();
+		$size = $this->formatSize($this->folderSize);
+		if (!$rows) {
+			$rows = [
+				$this->foldersCounter,
+				$this->filesCounter,
+				$this->imagesCounter,
+				$this->operationCounter,
+				$this->failedOperationCounter,
+				$niceDate,
+				$size
+			];
+		}
+		$table = new Table($output);
+		$table
+			->setHeaders($headers)
+			->setRows([$rows]);
+		$table->render();
+
+		$output->writeln("Last scanned file <info>$this->lastFile</info>");
+	}
+
+	/**
+	 * Shows details about failed operations
+	 *
+	 * @param string[] $headers
+	 * @param OutputInterface $output
+	 */
+	protected function showFailed($headers, OutputInterface $output) {
+		if (count($this->failedOperations)) {
+			$table = new Table($output);
+			$table->setHeaders($headers);
+			foreach ($this->failedOperations as $failedOperation) {
+				$table->addRow([$failedOperation]);
+			}
+			$table->render();
+		}
+	}
+
+	/**
+	 * Performs a given operation on a given user's file system
+	 *
+	 * @param string $scanOperation
+	 * @param string $user
+	 * @param string $dir
+	 * @param OutputInterface $output
+	 *
+	 * @return array
+	 * @throws ForbiddenCommandException|InputCommandException
+	 * @see OC\Files\Utils\Scanner::scan
+	 */
+	protected function performOperation($scanOperation, $user, $dir, OutputInterface $output
+	) {
+		if (!Filesystem::isValidPath($dir)) {
+			throw new InputCommandException('Invalid path to scan');
+		}
+		$mounts = $this->getMounts($dir, $user);
+		$result = [];
+		foreach ($mounts as $mount) {
+			$previewsAllowed = $mount->getOption('previews', true);
+			if (is_null($mount->getStorage()) || !$previewsAllowed) {
+				continue;
+			}
+			$storage = $mount->getStorage();
+			// if the home storage isn't writable then the scanner is run as the wrong user
+			if ($storage->instanceOfStorage('\OCP\Files\IHomeStorage') and
+				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
+			) {
+				throw new ForbiddenCommandException(
+					"<error>Home storage for user $user not writable</error>\nMake sure you're running the scan command only as the user the web server runs as"
+				);
+			}
+			// We can now execute the wanted operation
+			$result[] = call_user_func_array(
+				[$this, $scanOperation],
+				[$storage, $mount, $dir, $user, $output]
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Determines if we have a file
+	 *
+	 * @param Node $node
+	 *
+	 * @return bool
+	 */
+	protected function isFile(Node $node) {
+		$isFile = false;
+		// TODO: Find a more reliable way as we can't trust FileInfo
+		if ($node->getType() === 'file') {
+			$isFile = true;
+		}
+
+		return $isFile;
+	}
+
+	/**
+	 * Makes sure the folder or file exists in the user's filesystem
+	 *
+	 * @param string $path a full path or a relative path starting from the user's folder
+	 * @param string|null $user
+	 *
+	 * @return bool|Node
+	 *
+	 */
+	protected function getNode($path, $user = null) {
+		if ($user) {
+			$path = '/' . $user . '/' . $path;
+		}
+		if ($this->rootFolder->nodeExists($path)) {
+			return $this->rootFolder->get($path);
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function hasBeenInterrupted() {
+		$cancelled = false;
+		pcntl_signal_dispatch();
+		if ($this->interrupted) {
+			$cancelled = true;
+		}
+
+		return $cancelled;
+	}
+
+	/**
+	 * Asks for confirmation before proceeding
+	 *
+	 * @param InputInterface $input
+	 * @param string $question
+	 * @param OutputInterface $output
+	 *
+	 * @throws InputCommandException
+	 */
+	protected function getConfirmation(InputInterface $input, $question, OutputInterface $output) {
+		$helper = $this->getHelper('question');
+		$confirmationQuestion = new ConfirmationQuestion($question, false);
+
+		$quiet = false;
+		if ($output->getVerbosity() === 0) {
+			$quiet = true;
+			$output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+		}
+		if (!$helper->ask($input, $output, $confirmationQuestion)) {
+			throw new InputCommandException("Operation aborted");
+		}
+		if ($quiet) {
+			$output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+		}
+	}
+
+	/**
+	 * Tracks failed operations
+	 *
+	 * @param string $path
+	 * @param string $message
+	 * @param OutputInterface $output
+	 */
+	protected function trackFailedOperation($path, $message, OutputInterface $output) {
+		$this->failedOperationCounter++;
+		$this->failedOperations[] = $path;
+		$this->printToConsole("<error>$message</error>", $output);
+	}
+
+	/**
+	 * Prints a message to the console if we're not in quiet mode
+	 *
+	 * @param string $message
+	 * @param OutputInterface $output
+	 */
+	protected function printToConsole($message, OutputInterface $output) {
+		if (!$output->getVerbosity() === 0) {
+			$output->writeln($message);
+		}
+	}
+
+	/**
+	 * Changes the status of the command to "interrupted"
+	 *
+	 * Gives a chance to the command to properly terminate what it's doing
+	 */
+	private function cancelOperation() {
+		$this->interrupted = true;
+	}
+
+	/**
+	 * Makes sure the user has entered a valid path
+	 *
+	 * @param IUser[]|string[] $users
+	 * @param string $userInputErrorMsg
+	 *
+	 * @throws InputCommandException
+	 */
+	private function checkUserParameter($users, $userInputErrorMsg) {
+		if (count($users) === 0) {
+			throw new InputCommandException($userInputErrorMsg);
+		}
+	}
+
+	/**
+	 * Makes sure the user has entered a valid path
+	 *
+	 * It's too early to make sure the path is valid as we'll only mount the filesystem later in
+	 * the process
+	 *
+	 * @param string $pathInputErrorMsg
+	 *
+	 * @throws InputCommandException
+	 */
+	private function checkPathParameter($topFolder, $pathInputErrorMsg) {
+		if ($topFolder !== 'files') {
+			throw new InputCommandException($pathInputErrorMsg);
+		}
+	}
+
+	/**
+	 * Retrieves all storage mount points in $dir, including external ones
+	 *
+	 * @param string $dir
+	 * @param string $user
+	 *
+	 * @return IMountPoint[]
+	 * @throws InputCommandException
+	 * @see OC\Files\Utils\Scanner::getMounts
+	 */
+	private function getMounts($dir, $user) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($user);
+
+		$testPath = $this->rootFolder->nodeExists($dir);
+		if ($testPath) {
+			$mounts = $this->mountManager->findIn($dir);
+			$mounts[] = $this->mountManager->find($dir);
+			$mounts = array_reverse($mounts); //start with the mount of $dir
+
+			return $mounts;
+		} else {
+			throw new InputCommandException("The path provided does not exist");
+		}
+	}
+
+}


### PR DESCRIPTION
Sunday Funday!

Here are some command some of you may find useful to manage your thumbnails: 
## Create thumbnails

Solution for https://github.com/owncloud/core/issues/17536
### Documentation

[Create thumbnails](https://github.com/owncloud/gallery/wiki/Create-Thumbnails)
### Specs
- Collect user(s) or path info from the list of command arguments
- Die if encryption is enabled
- Compute path to analyse
- Only work with folders starting with `/<user>/files`
- Scan the given path using Cache\Scanner in order to work with reliable data
- Update the DB cache
- Generate previews **only for media types supported by the Gallery and for which we have a preview provider**
- Collect stats
#### Stats
- # of folders
- # of files
- # of images
- # of previews generated
- # of failed previews (listed)
- Time to complete request
- Last scanned file
- Size of processed data
### TODO
- [x] Quit if encryption is enabled
- [x] Only scan a mounted volume if previews are enabled for that storage location
- [x] Restrict scan to `/<user>/files`
- [x] Add some stats
- [x] Add a switch to force the regeneration of thumbnails
- [x] ~~Offer a safer scanning option, with transactional locking. I'm hoping this will solve the error 1205 problems and not create more problems when trying to generate thumbnails~~
- [x] Presents stats even if operation was cancelled
- [ ] Add tests 
- [ ] Make operation cancelling optional
- [ ] Use [OCP\Files\Cache\IPropagator](https://github.com/owncloud/core/blob/master/lib/public/files/cache/ipropagator.php) on 9
- [ ] Check if this is fixed https://github.com/owncloud/core/issues/17196
### Possible extensions

For future PRs
- Make coffee
- Support mimetype as a filter
## Delete thumbnails
### Documentation

[Delete thumbnails](https://github.com/owncloud/gallery/wiki/Delete-Thumbnails)
### Specs
- Collect user(s) or path info from the list of command arguments
- We do not care about encryption
- Wipe the thumbnails folders if we're asked to remove thumbnails for one, a few or all users
- Compute path to analyse in all other cases
- Search for files **of media type supported by Gallery and for which we have a preview provider** and delete as we go
- Collect stats
#### Stats
- # of images
- # of thumbnails deleted
- # of failed deletion (listed)
- Time to complete request
- Saved space
### Possible extensions

For future PRs
- There could be an option to delete thumbnails for all files. This would only be useful if the providers were changed in between the time the thumbnails were generated and the time at which the command is run
### TODO
- [x] Find an easy way to update the cache without re-scanning
- [x] Fix bug in core which prevents the use of a shared folder as the path (sub-folders work) https://github.com/owncloud/core/issues/19544 (8.1+)
- [x] Ask confirmation before launching the operation as we're deleting files from the system
- [ ] Add tests 
## Notes

Of course, it would be much more useful to be able to run that from a cron, from the user's settings panel, etc. so don't hesitate to improve this solution ;)

@mmattel @setnes @EricReiche @jospoortvliet @DeepDiver1975 @icewind1991 @Xenopathic @demattin @thedd @patman15 @africanforest @MorrisJobke @PVince81 @libasys @mbazdell @blackm 
