### PR TITLE
Purify SVGs

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -71,6 +71,7 @@ if (isset($request->server['REQUEST_URI'])) {
 		 */
 		Util::addScript($appName, 'vendor/bigshot/bigshot-compressed');
 		Util::addScript($appName, 'vendor/image-scale/image-scale.min');
+		Util::addScript($appName, 'vendor/dompurify/src/purify');
 		Util::addScript($appName, 'galleryfileaction');
 		Util::addScript($appName, 'slideshow');
 		Util::addScript($appName, 'slideshowcontrols');

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -37,6 +37,10 @@
 		register: function (mediaTypes) {
 			//console.log("enabledPreviewProviders: ", mediaTypes);
 			if (mediaTypes) {
+				// Remove SVG if the user is using an insecure browser (IE8-9)
+				if (window.galleryFileAction.features.indexOf('native_svg') > -1 && !window.btoa) {
+					mediaTypes.splice(mediaTypes.indexOf('image/svg+xml'), 1);
+				}
 				galleryFileAction.mediaTypes = mediaTypes;
 			}
 			var i, mediaTypesLength = mediaTypes.length;

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -1,3 +1,4 @@
+/* global DOMPurify */
 (function ($, OC, OCA, t) {
 	"use strict";
 	/**
@@ -172,9 +173,7 @@
 						this.imageCache[url].reject(url);
 					}
 				}.bind(this);
-				if (mimeType === 'image/svg+xml' &&
-					!document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image",
-						"1.1")) {
+				if (mimeType === 'image/svg+xml') {
 					image.src = this._getSVG(url);
 				} else {
 					image.src = url;
@@ -349,26 +348,17 @@
 		 */
 		_getSVG: function (source) {
 			var svgPreview = null;
-			if (window.btoa) {
+			// DOMPurify only works with IE10+ and we load SVGs in the IMG tag
+			if (window.btoa &&
+				document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image",
+					"1.1")) {
 				var xmlHttp = new XMLHttpRequest();
 				xmlHttp.open("GET", source, false);
 				xmlHttp.send(null);
 				if (xmlHttp.status === 200) {
-					if (xmlHttp.responseXML) {
-						// Has to be base64 encoded for Firefox
-						svgPreview =
-							"data:image/svg+xml;base64," + window.btoa(xmlHttp.responseText);
-					} else {
-						svgPreview = source;
-					}
+					var pureSvg = DOMPurify.sanitize(xmlHttp.responseText);
+					svgPreview = "data:image/svg+xml;base64," + window.btoa(pureSvg);
 				}
-			} else {
-				// This is exclusively for IE8
-				var message = t('gallery',
-					"<strong>Error!</strong> Your browser can't display SVG files.<br>" +
-					"Please use a more modern alternative");
-				this.showErrorNotification(message);
-				svgPreview = '/core/img/filetypes/image.png';
 			}
 
 			return svgPreview;

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -142,8 +142,7 @@ function Thumbnail (fileId, square) {
 									imageData = window.btoa(pureSvg);
 								}
 								thumb.image.src =
-									'data:' + preview.mimetype + ';base64,' +
-									imageData;
+									'data:' + preview.mimetype + ';base64,' + imageData;
 							} else {
 								thumb.valid = false;
 								thumb.image.src = Thumbnails._getMimeIcon(preview.mimetype);
@@ -159,7 +158,7 @@ function Thumbnail (fileId, square) {
 		 * Returns the link to the media type icon
 		 *
 		 * Modern browsers get an SVG, older ones a PNG
-		 * 
+		 *
 		 * @param mimeType
 		 *
 		 * @returns {*|string}

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -1,4 +1,4 @@
-/* global $, Gallery */
+/* global $, DOMPurify, Gallery */
 /**
  * A thumbnail is the actual image attached to the GalleryImage object
  *
@@ -136,8 +136,14 @@ function Thumbnail (fileId, square) {
 							};
 
 							if (thumb.status === 200) {
+								var imageData = preview.preview;
+								if (preview.mimetype === 'image/svg+xml') {
+									var pureSvg = DOMPurify.sanitize(window.atob(imageData));
+									imageData = window.btoa(pureSvg);
+								}
 								thumb.image.src =
-									'data:' + preview.mimetype + ';base64,' + preview.preview;
+									'data:' + preview.mimetype + ';base64,' +
+									imageData;
 							} else {
 								thumb.valid = false;
 								thumb.image.src = Thumbnails._getMimeIcon(preview.mimetype);


### PR DESCRIPTION
Fixes #373

Some purified SVGs can't be displayed until DOMPurify 0.71 is released: cure53/DOMPurify@86929b9

Good, simple SVGs on the other hand are properly displayed.
### Notes
- The API is not affected by the change since the client has to explicitly ask for a SVG and can implement his own purifier
- Native SVGs are not supported anywhere on IE8 and IE9
- Native SVGS are not supported in Gallery on all version of IE, but you do get a preview in the slideshow, even though you don't get a thumbnail...

@LukasReschke 
