### PR TITLE
Force Chrome to reload images after image.onerror

### DIFF
--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -132,7 +132,8 @@ function Thumbnail (fileId, square) {
 							};
 							thumb.image.onerror = function () {
 								thumb.valid = false;
-								thumb.image.src = Thumbnails._getMimeIcon(preview.mimetype);
+								var icon = Thumbnails._getMimeIcon(preview.mimetype);
+								setTimeout(function(){ thumb.image.src = icon; }, 0);
 							};
 
 							if (thumb.status === 200) {


### PR DESCRIPTION
Fixes "_Chrome it´s not showing the image file icon_" #397

@rperezb
