### PR TITLE
Simplify and fix album thumbnail presentation

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -14,7 +14,6 @@
 }
 
 #controls .button.view-switcher img{
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
 	filter: alpha(opacity=30);
 	opacity: .3;
 }
@@ -27,7 +26,6 @@
 }
 
 #controls .button.view-switcher.gallery img{
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 }
@@ -61,7 +59,6 @@
 .button.left-switch-button img,
 .button.right-switch-button img {
 	vertical-align: -3px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=60)";
 	filter: alpha(opacity=60);
 	opacity: 0.6;
 }
@@ -73,7 +70,6 @@
 }
 
 #controls .disabled-button img {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)";
 	filter: alpha(opacity=25);
 	opacity: 0.25;
 }

--- a/css/public.css
+++ b/css/public.css
@@ -37,14 +37,12 @@ body {
 	border: none;
 	margin: 2px 4px !important;
 	right: 0;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 }
 
 #save-button-confirm:hover,
 #save-button-confirm:focus {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity=100);
 	opacity: 1;
 }

--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -38,7 +38,6 @@
 	height: 52px;
 	position: absolute;
 	z-index: 1100;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 	background-position: center center;
@@ -49,7 +48,6 @@
 #slideshow.inactive > .progress,
 #slideshow.inactive > .menu input,
 #slideshow.inactive > .name {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
 	filter: alpha(opacity=0);
 	opacity: 0;
 	/* slow fadeout, fadein will be 300ms again*/
@@ -87,7 +85,6 @@
 #slideshow > input:hover,
 #slideshow > .menu input:hover,
 #slideshow.inactive > .name:hover {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
 	filter: alpha(opacity=75);
 	opacity: .75;
 }
@@ -123,7 +120,6 @@
 	right: 13px;
 	background-position: 0 100%;
 	width: 32px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 	height: 0;
@@ -146,7 +142,6 @@
 	box-shadow: none;
 	width: 52px;
 	height: 52px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 	background-position: center center;
@@ -172,7 +167,7 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
+	filter: alpha(opacity=75);
 	opacity: .75;
 }
 
@@ -188,7 +183,6 @@
 	top: 0;
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=90)";
 	filter: alpha(opacity=90);
 	opacity: .9;
 	left: 50%;

--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -128,6 +128,7 @@
 	opacity: .5;
 	height: 0;
 	min-height: 0;
+	cursor: pointer;
 }
 
 #slideshow > .menu {

--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -165,7 +165,7 @@
 	padding: 0 50px 3px;
 	text-align: center;
 	color: #fff;
-	text-shadow: 1px 1px 4px #333, 1px -1px 4px #333, -1px 1px 4px #333,-1px -1px 4px #333;
+	text-shadow: 1px 1px 4px #333, 1px -1px 4px #333, -1px 1px 4px #333, -1px -1px 4px #333;
 	font-size: 18px;
 	line-height: normal;
 	text-overflow: ellipsis;
@@ -183,13 +183,15 @@
 	border: 0;
 	padding: 1px 8px;
 	display: none;
-	position: relative;
+	position: absolute;
 	top: 0;
 	border-bottom-left-radius: 3px;
 	border-bottom-right-radius: 3px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=90)";
 	filter: alpha(opacity=90);
 	opacity: .9;
+	left: 50%;
+	transform: translate(-50%, 0);
 }
 
 #slideshow > .bigshotContainer {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,12 +1,4 @@
-/** Only available in OC8 */
-.hidden-visually {
-	position: absolute;
-	left: -10000px;
-	top: auto;
-	width: 1px;
-	height: 1px;
-	overflow: hidden;
-}
+/* IE 8 is not supported in the photowall */
 
 /** Preloading icons */
 body:after {
@@ -71,9 +63,6 @@ div.crumb.last a {
 	background-color: #fff;
 	overflow-x: auto;
 	-webkit-transition: background-color 1s linear;
-	-moz-transition: background-color 1s linear;
-	-o-transition: background-color 1s linear;
-	-ms-transition: background-color 1s linear;
 	transition: background-color 1s linear;
 }
 
@@ -97,22 +86,20 @@ div.crumb.last a {
 	margin-top: 2px;
 }
 
-#gallery .row a:first-child {
+#gallery .row .item-container:first-child {
 	margin-left: 4px;
 }
 
-#gallery .row a:last-child {
-	margin-right: 4px;
-}
-
-#gallery .row a {
+#gallery .row > .item-container {
+	position: relative;
 	display: inline-block;
 	height: auto;
 	padding: 0;
 	margin: 2px;
+	vertical-align: top;
 }
 
-#gallery a.album .album-label {
+#gallery .item-container .album-label {
 	color: #fff;
 	position: absolute;
 	left: 0;
@@ -128,7 +115,7 @@ div.crumb.last a {
 	z-index: 11;
 }
 
-#gallery a.image .image-label {
+#gallery .item-container .image-label {
 	display: none;
 	position: absolute;
 	left: 0;
@@ -141,12 +128,12 @@ div.crumb.last a {
 	word-break: break-all;
 }
 
-#gallery a.album .album-label,
-#gallery a.image .image-label {
+#gallery .item-container .album-label,
+#gallery .item-container .image-label {
 	background: rgba(0, 0, 0, 0.4);
 }
 
-#gallery a.image .image-label .title {
+#gallery .item-container .image-label .title {
 	display: inline-block;
 	color: #fff;
 	text-align: center;
@@ -158,7 +145,7 @@ div.crumb.last a {
 	text-overflow: ellipsis;
 }
 
-#gallery a.image .image-label .title:hover {
+#gallery .item-container .image-label .title:hover {
 	overflow: visible;
 	white-space: normal;
 }
@@ -166,6 +153,9 @@ div.crumb.last a {
 #gallery a.album > img {
 	max-width: 200px;
 	max-height: 200px;
+	position: relative;
+	float: left;
+	margin: 1px;
 }
 
 #gallery a {
@@ -185,23 +175,13 @@ div.crumb.last a {
 
 #gallery a.image > img {
 	max-height: 200px;
-	width: auto;
 }
 
-#gallery a.album,
+#gallery .cropped,
 #gallery .row {
 	opacity: 1;
-	transition: opacity 500ms;
-	-moz-transition: opacity 500ms;
-	-o-transition: opacity 500ms;
-	-ms-transition: opacity 500ms;
 	-webkit-transition: opacity 500ms;
-}
-
-#gallery a.album img {
-	position: relative;
-	float: left;
-	margin: 1px;
+	transition: opacity 500ms;
 }
 
 #gallery a.album .cropped {
@@ -210,11 +190,6 @@ div.crumb.last a {
 	margin: 1px;
 	background-position: center;
 	background-size: cover;
-}
-
-#gallery a.album.loading,
-#gallery .row.loading {
-	opacity: 0;
 }
 
 #gallery > h2 {

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -310,7 +310,7 @@
 		 *
 		 * @param {Array} images
 		 * @param {string} startImage
-		 * @param {bool} autoPlay
+		 * @param {boolean} autoPlay
 		 *
 		 * @returns {boolean}
 		 */
@@ -498,7 +498,7 @@
 		 * @param {string}token
 		 * @param {string}owner
 		 * @param {string}name
-		 * @param {bool} isProtected
+		 * @param {boolean} isProtected
 		 * @private
 		 */
 		_saveToOwnCloud: function (remote, token, owner, name, isProtected) {

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -244,7 +244,7 @@
 		 * @private
 		 */
 		_showFolder: function (targetHeight, a) {
-			var image = new GalleryImage('Generic folder', 'Generic folder', -1, 'image/png',
+			var image = new GalleryImage('Generic folder', 'Generic folder', -1, 'image/svg+xml',
 				Gallery.token);
 			var thumb = Thumbnails.getStandardIcon(-1);
 			image.thumbnail = thumb;

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -151,15 +151,15 @@
 		/**
 		 * Builds the album representation by placing 1 to 4 images on a grid
 		 *
-		 * @param {array<GalleryImage>} images
+		 * @param {Array<GalleryImage>} images
 		 * @param {number} targetHeight Each row has a specific height
 		 * @param {object} a
 		 *
-		 * @returns {$.Deferred<array>}
+		 * @returns {$.Deferred<Array>}
 		 * @private
 		 */
 		_getFourImages: function (images, targetHeight, a) {
-			var calcWidth = targetHeight / 2;
+			var calcWidth = targetHeight;
 			var targetWidth;
 			var imagesCount = images.length;
 			var def = new $.Deferred();
@@ -169,10 +169,14 @@
 
 			for (var i = 0; i < imagesCount; i++) {
 				targetWidth = calcWidth;
-				if (imagesCount === 2 || (imagesCount === 3 && i === 0)) {
-					targetWidth = calcWidth * 2;
+				// One picture filling the album
+				if (imagesCount === 1){
+					targetHeight = 2 * targetHeight;
 				}
-				targetWidth = targetWidth.toFixed(3);
+				// 2 bottom pictures out of 3, or 4 pictures have the size of a quarter of the album
+				if ((imagesCount === 3 && i !== 0) || imagesCount === 4) {
+					targetWidth = calcWidth / 2;
+				}
 
 				// Append the div first in order to not lose the order of images
 				var imageHolder = $('<div class="cropped">');
@@ -220,19 +224,15 @@
 		_fillSubAlbum: function (targetHeight, a) {
 			var album = this;
 
-			if (this.images.length > 1) {
+			if (this.images.length >= 1) {
 				this._getFourImages(this.images, targetHeight, a).fail(function (validImages) {
 					album.images = validImages;
 					album._fillSubAlbum(targetHeight, a);
 				});
-			} else if (this.images.length === 1) {
-				this._getOneImage(this.images[0], 2 * targetHeight, targetHeight,
-					a).fail(function () {
-					album.images = [];
-					album._showFolder(targetHeight, a);
-				});
 			} else {
-				this._showFolder(targetHeight, a);
+				var imageHolder = $('<div class="cropped">');
+				a.append(imageHolder);
+				this._showFolder(targetHeight, imageHolder);
 			}
 		},
 
@@ -240,17 +240,17 @@
 		 * Shows a folder icon in the album since we couldn't get any proper thumbnail
 		 *
 		 * @param {number} targetHeight
-		 * @param a
+		 * @param imageHolder
 		 * @private
 		 */
-		_showFolder: function (targetHeight, a) {
+		_showFolder: function (targetHeight, imageHolder) {
 			var image = new GalleryImage('Generic folder', 'Generic folder', -1, 'image/svg+xml',
 				Gallery.token);
 			var thumb = Thumbnails.getStandardIcon(-1);
 			image.thumbnail = thumb;
 			this.images.push(image);
 			thumb.loadingDeferred.done(function (img) {
-				a.append(img);
+				imageHolder.append(img);
 				img.height = (targetHeight - 2);
 				img.width = (targetHeight) - 2;
 			});

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -58,15 +58,17 @@
 		getThumbnailWidth: function () {
 			// img is a Thumbnail.image
 			return this.getThumbnail(false).then(function (img) {
+				var width = 0;
 				if (img) {
-					return img.originalWidth;
+					width = img.originalWidth;
 				}
-				return 0;
+
+				return width;
 			});
 		},
 
 		/**
-		 * Creates the a and img element in the DOM
+		 * Creates the container, the a and img elements in the DOM
 		 *
 		 * Each image is also a link to start the full screen slideshow
 		 *
@@ -80,39 +82,79 @@
 				this.domHeight = targetHeight;
 				// img is a Thumbnail.image
 				this.domDef = this.getThumbnail(false).then(function (img) {
+					var container = $('<div/>')
+						.addClass('item-container image-container')
+						.css('width', targetHeight * image.thumbnail.ratio)
+						.css('height', targetHeight);
+					image._addLabel(container);
+
+					var newWidth = Math.round(targetHeight * image.thumbnail.ratio);
+					container.attr('data-width', newWidth)
+						.attr('data-height', targetHeight);
+
+					var url = image._getLink();
+					var a = $('<a/>')
+						.addClass('image')
+						.attr('href', url)
+						.attr('data-path', image.path);
+
+					// This will stretch wide images to make them reach targetHeight
 					$(img).css({
-						'height': targetHeight,
-						'width': targetHeight * image.thumbnail.ratio
+						'width': targetHeight * image.thumbnail.ratio,
+						'height': targetHeight
 					});
 					img.alt = encodeURI(image.path);
-					var url = '#' + encodeURIComponent(image.path);
-
-					if (!image.thumbnail.valid) {
-						var params = {
-							c: image.etag,
-							requesttoken: oc_requesttoken
-						};
-						url = Gallery.utility.buildGalleryUrl('files', '/download/' + image.fileId,
-							params);
-					}
-					var a = $('<a/>').addClass('image').attr('href', url).attr('data-path',
-						image.path);
-
-					var imageLabel = $('<span/>').addClass('image-label');
-					var imageTitle = $('<span/>').addClass('title').text(
-						OC.basename(image.path));
-					imageLabel.append(imageTitle);
-					a.hover(function () {
-						imageLabel.slideToggle(OC.menuSpeed);
-					}, function () {
-						imageLabel.slideToggle(OC.menuSpeed);
-					});
-					a.append(imageLabel);
 					a.append(img);
-					return a;
+					container.append(a);
+
+					return container;
 				});
 			}
 			return this.domDef;
+		},
+
+		/**
+		 * Adds a label to the album
+		 *
+		 * @param container
+		 * @private
+		 */
+		_addLabel: function (container) {
+			var imageLabel = $('<span/>')
+				.addClass('image-label');
+			var imageTitle = $('<span/>')
+				.addClass('title').text(
+					OC.basename(this.path));
+			imageLabel.append(imageTitle);
+			container.hover(function () {
+				imageLabel.slideToggle(OC.menuSpeed);
+			}, function () {
+				imageLabel.slideToggle(OC.menuSpeed);
+			});
+			container.append(imageLabel);
+		},
+
+		/**
+		 * Generates the link for the click action of the image
+		 *
+		 * @returns {string}
+		 * @private
+		 */
+		_getLink: function () {
+			var url = '#' + encodeURIComponent(this.path);
+			if (!this.thumbnail.valid) {
+				var params = {
+					c: this.etag,
+					requesttoken: oc_requesttoken
+				};
+				url = Gallery.utility.buildGalleryUrl(
+					'files',
+					'/download/' + this.fileId,
+					params
+				);
+			}
+
+			return url;
 		}
 	};
 

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -37,7 +37,7 @@
 		/**
 		 * Returns a reference to a loading Thumbnail.image
 		 *
-		 * @param {bool} square
+		 * @param {boolean} square
 		 *
 		 * @returns {jQuery.Deferred<Thumbnail.image>}
 		 */

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -63,7 +63,7 @@
 		 */
 		getDom: function () {
 			var scaleRatio = (this.width > this.targetWidth) ? this.targetWidth / this.width : 1;
-			var targetHeight = 4 + (this.targetHeight * scaleRatio);
+			var targetHeight = this.targetHeight * scaleRatio;
 			targetHeight = targetHeight.toFixed(3);
 			var row = $('<div/>').addClass('row');
 			/**

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -11,11 +11,13 @@
 	var Row = function (targetWidth, requestId) {
 		this.targetWidth = targetWidth;
 		this.items = [];
-		this.width = 8; // 4px margin to start with
+		this.width = 4; // 4px margin to start with
 		this.requestId = requestId;
+		this.domDef = null;
 	};
 
 	Row.prototype = {
+		targetHeight: 200, // standard row height
 		/**
 		 * Adds sub-albums and images to the row until it's full
 		 *
@@ -28,7 +30,7 @@
 			var fileNotFoundStatus = 404;
 			var def = new $.Deferred();
 
-			var appendDom = function (width) {
+			var validateRowWidth = function (width) {
 				row.items.push(element);
 				row.width += width + 4; // add 4px for the margin
 				def.resolve(!row._isFull());
@@ -36,12 +38,13 @@
 
 			// No need to use getThumbnailWidth() for albums, the width is always 200
 			if (element instanceof Album) {
-				var width = 200;
-				appendDom(width);
+				var width = row.targetHeight;
+				validateRowWidth(width);
 			} else {
+				// We can't calculate the total width if we don't have the width of the thumbnail
 				element.getThumbnailWidth().then(function (width) {
 					if (element.thumbnail.status !== fileNotFoundStatus) {
-						appendDom(width);
+						validateRowWidth(width);
 					} else {
 						def.resolve(true);
 					}
@@ -60,7 +63,7 @@
 		 */
 		getDom: function () {
 			var scaleRatio = (this.width > this.targetWidth) ? this.targetWidth / this.width : 1;
-			var targetHeight = 200 * scaleRatio;
+			var targetHeight = 4 + (this.targetHeight * scaleRatio);
 			targetHeight = targetHeight.toFixed(3);
 			var row = $('<div/>').addClass('row');
 			/**

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -315,7 +315,7 @@
 		 *
 		 * @param {string} sortType name or date
 		 * @param {string} sortOrder asc or des
-		 * @param {bool} active determines if we're setting up the active sort button
+		 * @param {boolean} active determines if we're setting up the active sort button
 		 * @private
 		 */
 		_setSortButton: function (sortType, sortOrder, active) {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -306,7 +306,6 @@
 		 * @private
 		 */
 		_isTransparent: function (mimeType) {
-			// TODO: Include fonts
 			return !(mimeType === 'image/jpeg'
 				|| mimeType === 'image/x-dcraw'
 				|| mimeType === 'application/font-sfnt'

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -26,7 +26,7 @@
 		/**
 		 * Initialises the slideshow
 		 *
-		 * @param {bool} autoPlay
+		 * @param {boolean} autoPlay
 		 * @param {number} interval
 		 * @param {Array} features
 		 */
@@ -76,7 +76,7 @@
 		 * Refreshes the slideshow's data
 		 *
 		 * @param {{name:string, url: string, path: string, fallBack: string}[]} images
-		 * @param {bool} autoPlay
+		 * @param {boolean} autoPlay
 		 */
 		setImages: function (images, autoPlay) {
 			this._hideImage();

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -168,6 +168,7 @@
 			this.container.children('.previous').click(makeCallBack(this._previous));
 			this.container.children('.exit').click(makeCallBack(this._exit));
 			this.container.children('.pause, .play').click(makeCallBack(this._playPauseToggle));
+			this.progressBar.click(makeCallBack(this._playPauseToggle));
 		},
 
 		/**

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -301,6 +301,7 @@
 		 * @private
 		 */
 		_next: function () {
+			this._setName('');
 			this.slideshow.hideErrorNotification();
 			this.zoomablePreview.reset();
 
@@ -318,6 +319,7 @@
 		 * @private
 		 */
 		_previous: function () {
+			this._setName('');
 			this.slideshow.hideErrorNotification();
 			this.zoomablePreview.reset();
 

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -54,7 +54,7 @@
 		 * Updates the controls
 		 *
 		 * @param {{name:string, url: string, path: string, fallBack: string}[]} images
-		 * @param {bool} autoPlay
+		 * @param {boolean} autoPlay
 		 */
 		update: function (images, autoPlay) {
 			this.images = images;
@@ -107,7 +107,7 @@
 		 * Updates the private variables in case of problems loading an image
 		 *
 		 * @param {Array} images
-		 * @param {bool} errorLoadingImage
+		 * @param {boolean} errorLoadingImage
 		 */
 		updateControls: function (images, errorLoadingImage) {
 			this.images = images;

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -70,9 +70,9 @@ function Thumbnail (fileId, square) {
 				};
 
 				if (type === -1) {
-					icon = 'folder.svg';
+					icon = 'filetypes/folder';
 				}
-				thumb.image.src = OC.imagePath(Gallery.appName, icon);
+				thumb.image.src = OC.imagePath('core', icon);
 
 				Thumbnails.squareMap[type] = thumb;
 			}

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -3,7 +3,7 @@
  * A thumbnail is the actual image attached to the GalleryImage object
  *
  * @param {number} fileId
- * @param {bool} square
+ * @param {boolean} square
  * @constructor
  */
 function Thumbnail (fileId, square) {
@@ -28,7 +28,7 @@ function Thumbnail (fileId, square) {
 		 * Retrieves the thumbnail linked to the given fileID
 		 *
 		 * @param {number} fileId
-		 * @param {bool} square
+		 * @param {boolean} square
 		 *
 		 * @returns {Thumbnail}
 		 */
@@ -84,7 +84,7 @@ function Thumbnail (fileId, square) {
 		 * Loads thumbnails in batch, using EventSource
 		 *
 		 * @param {Array} ids
-		 * @param {bool} square
+		 * @param {boolean} square
 		 *
 		 * @returns {{}}
 		 */

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -5,7 +5,7 @@
 	<input type="button" class="svg pause icon-view-pause hidden"/>
 	<input type="button" class="svg previous icon-view-previous"/>
 	<input type="button" class="svg exit icon-view-close"/>
-
+	<div class="notification"></div>
 	<div class="menu">
 		<input type="button" class="menuItem svg downloadImage icon-view-download hidden"/>
 		<input type="button"
@@ -15,6 +15,5 @@
 	<div class="name">
 		<div class="title"></div>
 	</div>
-	<div class="notification"></div>
 	<div class="bigshotContainer"></div>
 </div>


### PR DESCRIPTION
### Main change

I've simplified the way album thumbnails are checked, discarded and put together.
There should now be an album icon in case of major failure when retrieving thumbnails belonging to that sub-album.
Commits:
- https://github.com/owncloud/gallery/commit/72d901dce19309f070d8e3471c99339cc1fb2587
- https://github.com/owncloud/gallery/commit/a873e1792b26b0cd1f7e052911294cf86dab38d1
### Minor changes

At the same time I've fixed some minor issues and kept that in separate commits.
- Fixes #390
- Fixes #389
- Fixes #407 (already approved)
- Better fix for #370
- Removed obsolete IE CSS
