### PR TITLE
Silence GD warnings which kill server side events

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -12,6 +12,8 @@
 
 namespace OCA\Gallery\AppInfo;
 
+ini_set("gd.jpeg_ignore_warning", true);
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 // A production environment will not have xdebug enabled and


### PR DESCRIPTION
GD throws warnings both when it has problems reading JPEGs  and when it has managed to process some data. Unfortunately, that second event makes the script return an error 500 which kills the rendering on the client side.
Fixes #420

In order to test this, you need to place a mangled JPEG, alone in a folder and you should get the spinning wheel.

I have no idea if this is the best place for that `ini_set`. Other possible locations are in the service itself and ideally, this should be dealt with in the Image class in `core`.

@LukasReschke @BernhardPosselt @nickvergessen 
