### PR TITLE
Fix album alignment while not breaking the footer

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -78,10 +78,13 @@ div.crumb.last a {
 }
 
 #gallery.hascontrols {
+	position: relative;
 	overflow: hidden;
 	text-align: justify;
 	top: 45px;
 	padding-bottom: 100px;
+	margin-bottom: 45px;
+	margin-top: 0;
 }
 
 #gallery .row {


### PR DESCRIPTION
Fixes #418 
## How to test
- Share an empty album
- Share an album with a few pictures
- Share an album with a lot of pictures

_Note: this can be one share with nested albums. In order to see the empty Gallery, you have to switch from the empty Files view_
## Public side
- [x] InfoBox still works properly
### Empty page
- [x] No scrollbar
- [x] Footer at the bottom
- [x] Empty message at 30%
### Page with only a couple of files
- [x] No scrollbar
- [x] Footer at the bottom of the row.
### Page with 3/4 content
- [x] No scrollbar
- [x] Footer at the bottom of the row.
### Page with list longer than the page
- [x] No double scrollbar
- [x] Footer at the bottom of the row
## Private side
- [x] When navigating from album to album, the starting position is always correct 
- [x] No unnecessary scrollbars
- [x] InfoBox still works properly

---

@jancborchardt @Henni 
