### PR TITLE
Add visual feedback when opening albums

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -99,6 +99,15 @@ div.crumb.last a {
 	vertical-align: top;
 }
 
+#gallery .row > .album-container > .album-loader {
+	position: absolute;
+	z-index: 11;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+}
+
 #gallery .item-container .album-label {
 	color: #fff;
 	position: absolute;


### PR DESCRIPTION
This provides some useful visual feedback to the user when trying to open an album located on slow storage
Fixes #416

The best way to use this is to open a share coming from another cloud.

_Note: includes #421_

---

@setnes @jancborchardt @demattin 
