### PR TITLE
Optimize breadcrumbs

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -11,7 +11,7 @@
 		appName: 'gallery',
 		token: undefined,
 		activeSlideShow: null,
-		buttonsWidth: 320,
+		buttonsWidth: 350,
 		browserToolbarHeight: 150,
 
 		/**

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -9,6 +9,7 @@
 	var View = function () {
 		this.element = $('#gallery');
 		this.loadVisibleRows.loading = false;
+		this.breadcrumb = new Gallery.Breadcrumb();
 	};
 
 	View.prototype = {
@@ -43,8 +44,8 @@
 					Gallery.showEmptyFolder();
 					this.hideButtons();
 					Gallery.currentAlbum = albumPath;
-					this.breadcrumb = new Gallery.Breadcrumb(albumPath);
-					this.breadcrumb.setMaxWidth($(window).width() - Gallery.buttonsWidth);
+					var availableWidth = $(window).width() - Gallery.buttonsWidth;
+					this.breadcrumb.init(albumPath, availableWidth);
 					Gallery.config.albumDesign = null;
 				}
 			} else {
@@ -229,7 +230,7 @@
 		},
 
 		/**
-		 * Sets up all the buttons of the interface
+		 * Sets up all the buttons of the interface and the breadcrumbs
 		 *
 		 * @param {string} albumPath
 		 * @private
@@ -238,8 +239,8 @@
 			this._shareButtonSetup(albumPath);
 			this._infoButtonSetup();
 
-			this.breadcrumb = new Gallery.Breadcrumb(albumPath);
-			this.breadcrumb.setMaxWidth($(window).width() - Gallery.buttonsWidth);
+			var availableWidth = $(window).width() - Gallery.buttonsWidth;
+			this.breadcrumb.init(albumPath, availableWidth);
 
 			$('#sort-name-button').show();
 			$('#sort-date-button').show();


### PR DESCRIPTION
Only hide/show elements instead of rebuilding the whole breadcrumbs every time it's being resized
Use Handlebars for the template to make it easier to modify.

The improvements are not really perceptible, but when you're resizing large photowall every little bit helps.
- [x] Breadcrumb works when navigating through albums
- [x] Breadcrumb shrinks when reaching deep albums
- [x] Ellipsis allows navigation to parent folder
- [x] Tooltip shows parent path
- [x] Breadcrumbs is usable on empty albums

_Note: includes #421 and #435_

---

@setnes @demattin if you want to give it a go
