### PR TITLE
remove unneeded icons from input fields to not distract from submit button, ref owncloud/core#18940

### DIFF
--- a/css/authenticate.css
+++ b/css/authenticate.css
@@ -19,7 +19,3 @@ input[type='submit'] {
 fieldset > p {
 	position: relative;
 }
-
-#password-icon {
-	top: 20px;
-}

--- a/templates/authenticate.php
+++ b/templates/authenticate.php
@@ -24,9 +24,6 @@ style('gallery', 'authenticate');
 				   placeholder="<?php p($l->t('Password')); ?>" value=""
 				   autocomplete="off" autocapitalize="off" autocorrect="off"
 				   autofocus/>
-			<img class="svg" id="password-icon" src="<?php print_unescaped(
-				image_path('', 'actions/password.svg')
-			); ?>" alt=""/>
 			<input type="submit" value="" class="svg icon-confirm input-button-inline"/>
 		</p>
 	</fieldset>


### PR DESCRIPTION
Same as https://github.com/owncloud/core/pull/20175 in core, here for the password protection field in Gallery public links.

Fixes #18940

Please review @owncloud/designers @oparoz @dragotin @enoch85 @HLFH
