### PR TITLE
If there is no browser history, exit the slideshow by calling stop.

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -347,11 +347,11 @@
 		_exit: function () {
 
 			// Only modern browsers can manipulate history
-			if (history && history.replaceState) {
+			if (history && history.replaceState && window.history.length > 1) {
 				// We simulate a click on the back button in order to be consistent
 				window.history.back();
 			} else {
-				// For ancient browsers supported in core
+				// There is no history to go back to.
 				this.stop();
 			}
 		},


### PR DESCRIPTION
This is a fix for #460.  

This is the same code that was in #463.  

I am renaming branches.  Sorry for any confusion.  :) 
