### PR TITLE
Show slideshow images in fullscreen

### DIFF
--- a/js/slideshowzoomablepreview.js
+++ b/js/slideshowzoomablepreview.js
@@ -50,8 +50,8 @@
 				this.zoomable = null;
 			}
 			var maxZoom = this.maxZoom;
-			var imgWidth = image.naturalWidth / window.devicePixelRatio;
-			var imgHeight = image.naturalHeight / window.devicePixelRatio;
+			var imgWidth = image.naturalWidth;
+			var imgHeight = image.naturalHeight;
 			// Disable zooming in IE when we can't get the image's size (SVG)
 			if (imgWidth === 0) {
 				$(image).attr('width', '100%')


### PR DESCRIPTION
The original image is 1200x849, but the slideshow applies CSS rules to show it smaller. I know that I can zoom in, but it's annoying since the resize doesn't try to fill the viewport as much as possible.

_First_

``` html
<img src="/index.php/apps/galleryplus/preview/59594?c=fc01f2275f4c1ebdc962202b35307850&amp;width=2900&amp;height=2900&amp;requesttoken=..." alt="51284906_p0_master1200.jpg" style="position: absolute; background-color: rgb(0, 0, 0); background-size: 660px 466.95px; top: 46px; left: 462px; background-position: 0px 0px; height: 466.95px; width: 660px;">
```

<img width="1440" alt="screen shot 2016-01-07 at 11 49 25" src="https://cloud.githubusercontent.com/assets/805144/12168781/c6d2536a-b534-11e5-8b80-feaee318ba08.png">

_Then_

``` html
<img src="/index.php/apps/gallery/preview/59594?c=fc01f2275f4c1ebdc962202b35307850&amp;width=2900&amp;height=2900&amp;requesttoken=..." alt="51284906_p0_master1200.jpg" style="position: absolute; background-color: rgb(0, 0, 0); background-size: 766.078px 542px; top: 0.28033px; height: 542px; left: 409.28px; width: 766.078px; background-position: 0px 0px;">
```

![screen shot 2016-01-08 at 01 22 23](https://cloud.githubusercontent.com/assets/805144/12186827/aad63f10-b5a6-11e5-8835-deb6b7981de2.jpg)

Latest stable versions of OSX and Firefox.
