### PR TITLE
Bring back smooth scrolling

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -85,7 +85,7 @@ class PageController extends Controller {
 		$params = ['appName' => $appName];
 
 		// Will render the page using the template found in templates/index.php
-		$response = new TemplateResponse($appName, 'index', $params);
+		$response = new TemplateResponse($appName, 'index', $params, 'public');
 		$this->addContentSecurityToResponse($response);
 
 		return $response;

--- a/css/public.css
+++ b/css/public.css
@@ -4,6 +4,15 @@ body {
 	width: 100%;
 }
 
+#content-wrapper {
+	background-color: #fff;
+	overflow-x: auto;
+	overflow-y: scroll;
+	-webkit-overflow-scrolling: touch;
+	-webkit-transition: background-color 1s linear;
+	transition: background-color 1s linear;
+}
+
 #content {
 	height: initial;
 	min-height: calc( 100vh - 120px );

--- a/css/styles.css
+++ b/css/styles.css
@@ -62,8 +62,16 @@ div.crumb.last a {
 #content-wrapper {
 	background-color: #fff;
 	overflow-x: auto;
+	overflow-y: scroll;
+	-webkit-overflow-scrolling: touch;
 	-webkit-transition: background-color 1s linear;
 	transition: background-color 1s linear;
+}
+
+#content {
+	height: initial;
+	min-height: calc( 100vh - 120px );
+	overflow: hidden;
 }
 
 #gallery.hascontrols {
@@ -71,7 +79,6 @@ div.crumb.last a {
 	overflow: hidden;
 	text-align: justify;
 	top: 45px;
-	padding-bottom: 100px;
 	margin-bottom: 45px;
 	margin-top: 0;
 }

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -42,6 +42,60 @@ style(
 	]
 );
 ?>
+<div id="notification-container">
+	<div id="notification" style="display: none;"></div>
+</div>
+<header>
+	<div id="header">
+		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
+		   title="" id="owncloud">
+			<div class="logo-icon svg">
+			</div>
+		</a>
+
+		<div class="header-appname-container">
+			<h1 class="header-appname">
+				<?php
+				if (\OCP\App::isEnabled('enterprise_key')) {
+					print_unescaped($theme->getHTMLName());
+				} else {
+					p($theme->getName());
+				}
+				?>
+			</h1>
+		</div>
+
+		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
+		<div class="header-right">
+			<span id="details">
+				<?php
+				if ($_['server2ServerSharing']) {
+					?>
+					<span id="save" data-protected="<?php p($_['protected']) ?>"
+						  data-owner="<?php p($_['displayName']) ?>"
+						  data-name="<?php p($_['filename']) ?>">
+									<button id="save-button"><?php p(
+											$l->t('Add to your ownCloud')
+										) ?></button>
+									<form class="save-form hidden" action="#">
+										<input type="text" id="remote_address"
+											   placeholder="example.com/owncloud"/>
+										<button id="save-button-confirm"
+												class="icon-confirm svg"></button>
+									</form>
+								</span>
+				<?php } ?>
+				<a id="download" class="button">
+					<img class="svg" src="<?php print_unescaped(
+						image_path('core', 'actions/download.svg')
+					); ?>" alt=""/>
+						<span id="download-text"><?php p($l->t('Download')) ?>
+						</span>
+				</a>
+			</span>
+		</div>
+	</div>
+</header>
 <div id="controls">
 	<div id='breadcrumbs'></div>
 	<div class="left">
@@ -97,7 +151,17 @@ style(
 		</div>
 	</span>
 </div>
-<div id="gallery" class="hascontrols"></div>
-<div id="emptycontent" class="hidden"></div>
-<div id="loading-indicator" class="loading"></div>
-<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
+<div id="content-wrapper">
+	<div id="content" class="app-<?php p($_['appName']) ?>"
+		 data-albumname="<?php p($_['albumName']) ?>">
+		<div id="app">
+			<div id="gallery" class="hascontrols"></div>
+			<div id="emptycontent" class="hidden"></div>
+			<div id="loading-indicator" class="loading"></div>
+			<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
+		</div>
+	</div>
+	<footer>
+		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>
+	</footer>
+</div>

--- a/templates/public.php
+++ b/templates/public.php
@@ -97,55 +97,56 @@ style(
 		</div>
 	</div>
 </header>
+<div id="controls">
+	<div id="breadcrumbs"></div>
+	<!-- sorting buttons -->
+	<div class="left">
+		<div id="sort-date-button" class="button sorting right-switch-button">
+			<div class="flipper">
+				<img class="svg asc front" src="<?php print_unescaped(
+					image_path($_['appName'], 'dateasc.svg')
+				); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
+				<img class="svg des back" src="<?php print_unescaped(
+					image_path($_['appName'], 'datedes.svg')
+				); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
+			</div>
+		</div>
+		<div id="sort-name-button" class="button sorting left-switch-button">
+			<div class="flipper">
+				<img class="svg asc front" src="<?php print_unescaped(
+					image_path($_['appName'], 'nameasc.svg')
+				); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
+				<img class="svg des back" src="<?php print_unescaped(
+					image_path($_['appName'], 'namedes.svg')
+				); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
+			</div>
+		</div>
+	</div>
+	<span class="right">
+		<!-- info button -->
+		<div id="album-info-button" class="button">
+			<span class="ribbon black"></span>
+			<img class="svg" src="<?php print_unescaped(
+				image_path('core', 'actions/info.svg')
+			); ?>" alt="<?php p($l->t('Album information')); ?>"/>
+		</div>
+		<div class="album-info-container">
+			<div class="album-info-loader"></div>
+			<div class="album-info-content markdown-body"></div>
+		</div>
+		<!-- button for opening the current album as file list -->
+		<div id="filelist-button" class="button view-switcher gallery">
+			<div id="button-loading"></div>
+			<img class="svg" src="<?php print_unescaped(
+				image_path('core', 'actions/toggle-filelist.svg')
+			); ?>" alt="<?php p($l->t('Picture view')); ?>"/>
+		</div>
+	</span>
+</div>
 <div id="content-wrapper">
 	<div id="content" class="app-<?php p($_['appName']) ?>"
 		 data-albumname="<?php p($_['albumName']) ?>">
 		<div id="app">
-			<div id="controls">
-				<div id="breadcrumbs"></div>
-				<!-- sorting buttons -->
-				<div class="left">
-					<div id="sort-date-button" class="button sorting right-switch-button">
-						<div class="flipper">
-							<img class="svg asc front" src="<?php print_unescaped(
-								image_path($_['appName'], 'dateasc.svg')
-							); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
-							<img class="svg des back" src="<?php print_unescaped(
-								image_path($_['appName'], 'datedes.svg')
-							); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
-						</div>
-					</div>
-					<div id="sort-name-button" class="button sorting left-switch-button">
-						<div class="flipper">
-							<img class="svg asc front" src="<?php print_unescaped(
-								image_path($_['appName'], 'nameasc.svg')
-							); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
-							<img class="svg des back" src="<?php print_unescaped(
-								image_path($_['appName'], 'namedes.svg')
-							); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
-						</div>
-					</div>
-				</div>
-				<span class="right">
-					<div id="album-info-button" class="button">
-						<span class="ribbon black"></span>
-						<img class="svg" src="<?php print_unescaped(
-							image_path('core', 'actions/info.svg')
-						); ?>" alt="<?php p($l->t('Album information')); ?>"/>
-					</div>
-					<div class="album-info-container">
-						<div class="album-info-loader"></div>
-						<div class="album-info-content markdown-body"></div>
-					</div>
-					<!-- toggle for opening the current album as file list -->
-					<div id="filelist-button" class="button view-switcher gallery">
-						<div id="button-loading"></div>
-						<img class="svg" src="<?php print_unescaped(
-							image_path('core', 'actions/toggle-filelist.svg')
-						); ?>" alt="<?php p($l->t('Picture view')); ?>"/>
-					</div>
-				</span>
-			</div>
 			<div id="gallery" class="hascontrols"
 				 data-requesttoken="<?php p($_['requesttoken']) ?>"
 				 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
@@ -158,4 +159,3 @@ style(
 		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>
 	</footer>
 </div>
-


### PR DESCRIPTION
First attempt at fixing #500.

The improvements range from _not visible_ to _astonishing_ on the devices I've tested. The devices which benefit the most seem to be iOS based.

This introduces the changes that @fuhaoshih tried to introduce with https://github.com/owncloud/gallery/pull/285, but without the side effects (at least in the scrolling).

**The best quick test you can do is scroll through a list of files on the Files side and then switch to Gallery and scroll again.**

The standard and public templates should be combined in a future PR as they're very similar now.
## Platforms
### Desktop
- Chromium/win10: no visible change
- Firefox/win10: no visible change
- Edge/win10: no visible change
- IE11/win10: no visible change
### Mobile
- Chrome/ios9: huge performance gains. Activates smooth kinetic scrolling
- Safari/ios9: huge performance gains. Activates smooth kinetic scrolling with bouncing edges
- Browser/BB10: improves scrolling performance
- Chrome/Android 4.x: huge performance gains. Activates smooth kinetic scrolling
- Firefox/Android 4.x: no visible change. Seems like hardware acceleration is not available on 4.x
- Chrome/Android 5.x
- Firefox/Android 5.x
- Chrome/Android 6.x
- Firefox/Android 6.x

---

@jancborchardt @henni @setnes @demattin @mmattel @Spacefish @Bugsbane @MorrisJobke @jospoortvliet 
