### PR TITLE
[9.0] Fix local tests

### DIFF
--- a/tests/_support/Helper/CoreTestCase.php
+++ b/tests/_support/Helper/CoreTestCase.php
@@ -18,6 +18,8 @@ namespace Helper;
  * This class is created in order to avoid having to stay in sync with the content of these methods
  * in core
  *
+ * @group DB
+ *
  * @package OCA\Gallery\Tests\Helper
  */
 class CoreTestCase extends \Test\TestCase {

--- a/tests/integration/appinfo/ApplicationTest.php
+++ b/tests/integration/appinfo/ApplicationTest.php
@@ -29,7 +29,7 @@ class ApplicationTest extends GalleryIntegrationTest {
 			['FilesPublicController', 'OCA\Gallery\Controller\FilesPublicController'],
 			['PreviewController', 'OCA\Gallery\Controller\PreviewController'],
 			['PreviewPublicController', 'OCA\Gallery\Controller\PreviewPublicController'],
-			['L10N', '\OC_L10N']
+			['L10N', '\OCP\IL10N']
 		];
 	}
 


### PR DESCRIPTION
Integration and API tests now have to belong to the DB group in order to be able to run locally.
