### PR TITLE
Instant thumbnails showing

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -57,10 +57,3 @@ body {
 #gallery.hascontrols {
 	padding-bottom: 0;
 }
-
-#loading-indicator {
-	height: 32px;
-	width: 100%;
-	margin-top: 100px;
-	margin-bottom: 0;
-}

--- a/css/styles.css
+++ b/css/styles.css
@@ -285,12 +285,6 @@ http://www.bypeople.com/author/comatosed/*/
 	border-color: #bbb #bbb transparent #bbb;
 }
 
-#loading-indicator {
-	height: 32px;
-	width: 100%;
-	margin-bottom: 50px;
-}
-
 .icon-gallery {
 	background-image: url('../img/gallery-dark.svg');
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -189,13 +189,18 @@ div.crumb.last a {
 	opacity: .5;
 }
 
+#gallery a {
+	-webkit-transition: all .2s ease-in-out;
+	transition: all .2s ease-in-out;
+}
+
 #gallery a.image > img {
 	max-height: 200px;
 }
 
 #gallery .cropped,
 #gallery .row {
-	opacity: 1;
+	opacity: 0.5;
 	-webkit-transition: opacity 500ms;
 	transition: opacity 500ms;
 }
@@ -206,6 +211,16 @@ div.crumb.last a {
 	margin: 1px;
 	background-position: center;
 	background-size: cover;
+}
+
+#gallery a.album .icon-loading,
+#gallery .image-container .icon-loading {
+	margin: auto;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
 }
 
 #gallery > h2 {

--- a/css/styles.css
+++ b/css/styles.css
@@ -106,7 +106,8 @@ div.crumb.last a {
 	vertical-align: top;
 }
 
-#gallery .row > .album-container > .album-loader {
+#gallery .row > .album-container > .album-loader,
+#gallery .row > .image-container > .image-loader{
 	position: absolute;
 	z-index: 11;
 	top: 0;

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -272,7 +272,6 @@
 			emptyContentElement.html(message);
 			emptyContentElement.removeClass('hidden');
 			$('#controls').addClass('hidden');
-			$('#loading-indicator').hide();
 		},
 
 		/**

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -13,7 +13,7 @@
 		this.items = [];
 		this.width = 4; // 4px margin to start with
 		this.requestId = requestId;
-		this.domDef = null;
+		this.domDef = $('<div/>').addClass('row');
 	};
 
 	Row.prototype = {
@@ -29,12 +29,16 @@
 			var row = this;
 			var fileNotFoundStatus = 404;
 			var def = new $.Deferred();
+			var itemDom;
 
 			var validateRowWidth = function (width) {
 				row.items.push(element);
 				row.width += width + 4; // add 4px for the margin
 				def.resolve(!row._isFull());
 			};
+
+			itemDom = element.getDom(row.targetHeight);
+			row.domDef.append(itemDom);
 
 			// No need to use getThumbnailWidth() for albums, the width is always 200
 			if (element instanceof Album) {
@@ -44,11 +48,14 @@
 				// We can't calculate the total width if we don't have the width of the thumbnail
 				element.getThumbnailWidth().then(function (width) {
 					if (element.thumbnail.status !== fileNotFoundStatus) {
+						element.resize(row.targetHeight);
 						validateRowWidth(width);
 					} else {
+						itemDom.remove();
 						def.resolve(true);
 					}
 				}, function () {
+					itemDom.remove();
 					def.resolve(true);
 				});
 			}
@@ -57,33 +64,43 @@
 		},
 
 		/**
-		 * Creates the row element in the DOM
+		 * Returns the DOM element of the row
 		 *
 		 * @returns {*}
 		 */
 		getDom: function () {
+			return this.domDef;
+		},
+
+		/**
+		 * Resizes the row once it's full
+		 */
+		fit: function () {
 			var scaleRatio = (this.width > this.targetWidth) ? this.targetWidth / this.width : 1;
-			var targetHeight = this.targetHeight * scaleRatio;
+
+			// This animates the elements when the window is resized
+			var targetHeight = 4 + (this.targetHeight * scaleRatio);
 			targetHeight = targetHeight.toFixed(3);
-			var row = $('<div/>').addClass('row');
-			/**
-			 * @param {*} row
-			 * @param {GalleryImage[]|Album[]} items
-			 * @param {number} i
-			 *
-			 * @returns {*}
-			 */
-			var addImageToDom = function (row, items, i) {
-				return items[i].getDom(targetHeight).then(function (itemDom) {
-					i++;
-					row.append(itemDom);
-					if (i < items.length) {
-						return addImageToDom(row, items, i);
-					}
-					return row;
-				});
-			};
-			return addImageToDom(row, this.items, 0);
+			this.domDef.height(targetHeight);
+			this.domDef.width(this.width * scaleRatio);
+
+			// Resizes and scales all photowall elements to make them fit within the window's width
+			this.domDef.find('.item-container').each(function () {
+				// Necessary since DOM elements are not resized when CSS transform is used
+				$(this).css('width', $(this).data('width') * scaleRatio)
+					.css('height', $(this).data('height') * scaleRatio);
+				// This scales the anchors inside the item-container divs
+				$(this).children('a').css('transform-origin', 'left top')
+					.css('-webkit-transform-origin', 'left top')
+					.css('-ms-transform-origin', 'left top')
+					.css('transform', 'scale(' + scaleRatio + ')')
+					.css('-webkit-transform', 'scale(' + scaleRatio + ')')
+					.css('-ms-transform', 'scale(' + scaleRatio + ')');
+			});
+
+			// Restore the rows to their normal opacity. This happens immediately with rows
+			// containing albums only
+			this.domDef.css('opacity', 1);
 		},
 
 		/**

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -141,7 +141,7 @@
 			// 2 windows worth of rows is the limit from which we need to start loading new rows.
 			// As we scroll down, it grows
 			var targetHeight = ($(window).height() * 2) + scroll;
-			var showRows = function (album) {
+			var showRows = _.throttle(function (album) {
 
 				// If we've reached the end of the album, we kill the loader
 				if (!(album.viewedItems < album.subAlbums.length + album.images.length)) {
@@ -185,7 +185,7 @@
 					// Something went wrong, so kill the loader
 					view.loadVisibleRows.loading = null;
 				});
-			};
+			}, 100);
 			if (this.element.height() < targetHeight) {
 				this.loadVisibleRows.loading = true;
 				this.loadVisibleRows.loading = showRows(album);

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -153,46 +153,41 @@
 
 				// Everything is still in sync, since no deferred calls have been placed yet
 
-				return album.getNextRow($(window).width()).then(function (row) {
+				var row = album.getRow($(window).width(), view.requestId);
+				var rowDom = row.getDom();
+				view.element.append(rowDom);
 
+				return album.fillNextRow(row).then(function () {
 					/**
 					 * At this stage, the row has a width and contains references to images based
 					 * on
 					 * information available when making the request, but this information may have
 					 * changed while we were receiving thumbnails for the row
 					 */
-
 					if (view.requestId === row.requestId) {
-						return row.getDom().then(function (dom) {
-
-							if (Gallery.currentAlbum !== path) {
-								view.loadVisibleRows.loading = null;
-								return; //throw away the row if the user has navigated away in the
-										// meantime
-							}
-							if (view.element.length === 1) {
-								Gallery.showNormal();
-							}
-
-							view.element.append(dom);
-
-							if (album.viewedItems < album.subAlbums.length + album.images.length &&
-								view.element.height() < targetHeight) {
-								return showRows(album);
-							}
-
-							// No more rows to load at the moment
+						if (Gallery.currentAlbum !== path) {
 							view.loadVisibleRows.loading = null;
-							$('#loading-indicator').hide();
-						}, function () {
-							// Something went wrong, so kill the loader
-							view.loadVisibleRows.loading = null;
-							$('#loading-indicator').hide();
-						});
+							return; //throw away the row if the user has navigated away in the
+									// meantime
+						}
+						if (view.element.length === 1) {
+							Gallery.showNormal();
+						}
+						if (album.viewedItems < album.subAlbums.length + album.images.length &&
+							view.element.height() < targetHeight) {
+							return showRows(album);
+						}
+						// No more rows to load at the moment
+						view.loadVisibleRows.loading = null;
+						$('#loading-indicator').hide();
+					} else {
+						// This is the safest way to do things
+						view.viewAlbum(Gallery.currentAlbum);
 					}
-					// This is the safest way to do things
-					view.viewAlbum(Gallery.currentAlbum);
-
+				}, function () {
+					// Something went wrong, so kill the loader
+					view.loadVisibleRows.loading = null;
+					$('#loading-indicator').hide();
 				});
 			};
 			if (this.element.height() < targetHeight) {

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -80,7 +80,6 @@
 			}
 
 			this.clear();
-			$('#loading-indicator').show();
 
 			if (albumPath !== Gallery.currentAlbum) {
 				this.loadVisibleRows.loading = false;
@@ -147,7 +146,6 @@
 				// If we've reached the end of the album, we kill the loader
 				if (!(album.viewedItems < album.subAlbums.length + album.images.length)) {
 					view.loadVisibleRows.loading = null;
-					$('#loading-indicator').hide();
 					return;
 				}
 
@@ -179,7 +177,6 @@
 						}
 						// No more rows to load at the moment
 						view.loadVisibleRows.loading = null;
-						$('#loading-indicator').hide();
 					} else {
 						// This is the safest way to do things
 						view.viewAlbum(Gallery.currentAlbum);
@@ -187,7 +184,6 @@
 				}, function () {
 					// Something went wrong, so kill the loader
 					view.loadVisibleRows.loading = null;
-					$('#loading-indicator').hide();
 				});
 			};
 			if (this.element.height() < targetHeight) {
@@ -198,7 +194,6 @@
 		},
 
 		hideButtons: function () {
-			$('#loading-indicator').hide();
 			$('#album-info-button').hide();
 			$('#share-button').hide();
 			$('#sort-name-button').hide();

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -157,7 +157,6 @@ style(
 		<div id="app">
 			<div id="gallery" class="hascontrols"></div>
 			<div id="emptycontent" class="hidden"></div>
-			<div id="loading-indicator" class="loading"></div>
 			<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
 		</div>
 	</div>

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -154,11 +154,9 @@ style(
 <div id="content-wrapper">
 	<div id="content" class="app-<?php p($_['appName']) ?>"
 		 data-albumname="<?php p($_['albumName']) ?>">
-		<div id="app">
-			<div id="gallery" class="hascontrols"></div>
-			<div id="emptycontent" class="hidden"></div>
-			<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
-		</div>
+		<div id="gallery" class="hascontrols"></div>
+		<div id="emptycontent" class="hidden"></div>
+		<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
 	</div>
 	<footer>
 		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>

--- a/templates/public.php
+++ b/templates/public.php
@@ -152,7 +152,6 @@ style(
 				 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
 			</div>
 			<div id="emptycontent" class="hidden"></div>
-			<div id="loading-indicator" class="loading"></div>
 		</div>
 	</div>
 	<footer>

--- a/templates/public.php
+++ b/templates/public.php
@@ -146,13 +146,11 @@ style(
 <div id="content-wrapper">
 	<div id="content" class="app-<?php p($_['appName']) ?>"
 		 data-albumname="<?php p($_['albumName']) ?>">
-		<div id="app">
-			<div id="gallery" class="hascontrols"
-				 data-requesttoken="<?php p($_['requesttoken']) ?>"
-				 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
-			</div>
-			<div id="emptycontent" class="hidden"></div>
+		<div id="gallery" class="hascontrols"
+			 data-requesttoken="<?php p($_['requesttoken']) ?>"
+			 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
 		</div>
+		<div id="emptycontent" class="hidden"></div>
 	</div>
 	<footer>
 		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>


### PR DESCRIPTION
Replaces #497

Improves the feedback shown to users to let them know that something is happening when thumbnails have not been generated yet. This replaces the spinner added below the row.

Fixes #29

The improvements are better seen on albums which contain sub-albums as these should show some activity before the full row has been rendered.
### Screencasts

_Note: the refresh rate in the videos is quite low, so this is not reflective of the smootheness of the animation_

**With cached thumbnails**
http://screencast-o-matic.com/watch/cDn6n7hR39

You can see that once the album is cached, there is no resizing taking place any more

**On an empty cache**
http://screencast-o-matic.com/watch/cDn6nEhR3E
### Features:
- Semi-opaque row while it's being filled
- Spinners on images in albums
- Spinners on single images on row (with caveat, see below)
### Caveats
- Since we don't have the real size of the images, the next image or its spinner are sometimes misaligned. It's currently impossible to fix and has to be accepted as a side-effect of being able to show some information before having the full picture
- When resizing the window on a desktop, there is a flashing effect as each time the wall is being redrawn, the opacity goes back to being semi-transparent until the images are resized. In my experience, the fix involves introducing and monitoring a state to know if we're currently in a resizing loop. I don't think it's worth for me to invest time to improve this, but a PR can certainly be introduced later if someone finds a better way
- On low powered devices, there may be a bit of stuttering when resizing very wide images. I find this acceptable, compared to the advantages.
### Tested on
- Windows 10 Firefox, Chrome
- OSX Chrome
- BlackBerry 10
- iOS
- Android 4.3

---

@jancborchardt @jospoortvliet @setnes @demattin @arkascha @elpraga @sualko @bugsbane @mmattel 
