### PR TITLE
[WIP] add full size preview if previews are disabled

### DIFF
--- a/controller/config.php
+++ b/controller/config.php
@@ -52,7 +52,9 @@ trait Config {
 		$mediaTypes =
 			$this->configService->getSupportedMediaTypes($extraMediaTypes, $nativeSvgSupport);
 
-		return ['features' => $features, 'mediatypes' => $mediaTypes];
+		$enablePreviews = \OC::$server->getConfig()->getSystemValue('enable_previews',  true);
+
+		return ['features' => $features, 'mediatypes' => $mediaTypes, 'enablePreviews' => $enablePreviews];
 	}
 
 	/**

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -215,7 +215,7 @@ $(document).ready(function () {
 	$.getJSON(url).then(function (config) {
 		window.galleryFileAction.buildFeaturesList(config.features);
 
-		if (config.mediatypes.length === 0) {
+		if (!config.enablePreviews) {
 			config.mediatypes = ['image/png', 'image/jpeg', 'image/gif'];
 			window.galleryFileAction.previewsDisabled = true;
 			$('#gallery-button').remove();

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -111,7 +111,13 @@
 						c: file.etag,
 						requesttoken: oc_requesttoken
 					};
-					imageUrl = galleryFileAction.buildGalleryUrl('preview', '/' + file.id, params);
+					if (galleryFileAction.previewsDisabled) {
+						imageUrl = OC.generateUrl('apps/files/ajax/download.php');
+						imageUrl += '?dir=' + encodeURIComponent(dir);
+						imageUrl += '&files=' + encodeURIComponent(file.name);
+					} else {
+						imageUrl = galleryFileAction.buildGalleryUrl('preview', '/' + file.id, params);
+					}
 					params = {
 						c: file.etag,
 						requesttoken: oc_requesttoken
@@ -210,6 +216,13 @@ $(document).ready(function () {
 	var url = window.galleryFileAction.buildGalleryUrl('config', '', {extramediatypes: 1});
 	$.getJSON(url).then(function (config) {
 		window.galleryFileAction.buildFeaturesList(config.features);
+
+		if (config.mediatypes.length === 0) {
+			config.mediatypes = ['image/png', 'image/jpeg', 'image/gif', 'image/x-xbitmap', 'image/bmp'];
+			window.galleryFileAction.previewsDisabled = true;
+			$('#gallery-button').remove();
+		}
+
 		window.galleryFileAction.register(config.mediatypes);
 	});
 });

--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -112,9 +112,7 @@
 						requesttoken: oc_requesttoken
 					};
 					if (galleryFileAction.previewsDisabled) {
-						imageUrl = OC.generateUrl('apps/files/ajax/download.php');
-						imageUrl += '?dir=' + encodeURIComponent(dir);
-						imageUrl += '&files=' + encodeURIComponent(file.name);
+						imageUrl = OCA.Files.Files.getDownloadUrl(file.name, dir);
 					} else {
 						imageUrl = galleryFileAction.buildGalleryUrl('preview', '/' + file.id, params);
 					}
@@ -218,7 +216,7 @@ $(document).ready(function () {
 		window.galleryFileAction.buildFeaturesList(config.features);
 
 		if (config.mediatypes.length === 0) {
-			config.mediatypes = ['image/png', 'image/jpeg', 'image/gif', 'image/x-xbitmap', 'image/bmp'];
+			config.mediatypes = ['image/png', 'image/jpeg', 'image/gif'];
 			window.galleryFileAction.previewsDisabled = true;
 			$('#gallery-button').remove();
 		}


### PR DESCRIPTION
fix #488 

To test this you have to add <code>'enable_previews' => false</code> to your oc config. Afterwards you should be able to view all your images in the file app as usual.

Any advice how to clean this up?

@oparoz @XANi
