### PR TITLE
Also hide the progress icon when toggling play/pause icons

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -60,7 +60,7 @@
 			this.images = images;
 			this.active = true;
 			this.showButton('.play');
-			this.hideButton('.pause');
+			this.hideButton('.pause, .progress');
 			this.playing = false;
 
 			// Hide prev/next and play buttons when we only have one pic
@@ -296,7 +296,7 @@
 				this._setTimeout();
 			}
 
-			this.container.find('.play, .pause').toggleClass('hidden');
+			this.container.find('.play, .pause, .progress').toggleClass('hidden');
 		},
 
 		/**


### PR DESCRIPTION
Fixes: #51
### Description

When hiding/showing the play and pause icons, we also need to take into consideration the progress icon. This PR takes care of that.
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
- [ ] Android 4.x/Chrome
- [x] iOS9/Safari
### Check list
- [x] Code is properly documented
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@jancborchardt @MorrisJobke @setnes @demattin 
