### PR TITLE
Keep panning when reaching touch areas

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -169,9 +169,11 @@
 			this.container.children('.exit').click(makeCallBack(this._exit));
 			this.container.children('.pause, .play').click(makeCallBack(this._playPauseToggle));
 			this.progressBar.click(makeCallBack(this._playPauseToggle));
-			this.container.children('.previous, .next, .menu, .name').on('mousewheel DOMMouseScroll',function (evn){
-				this.container.children('.bigshotContainer')[0].dispatchEvent(new WheelEvent(evn.originalEvent.type,evn.originalEvent));
-			}.bind(this));
+			this.container.children('.previous, .next, .menu, .name').on(
+				'mousewheel DOMMouseScroll mousemove', function (evn) {
+					this.container.children('.bigshotContainer')[0].dispatchEvent(
+						new WheelEvent(evn.originalEvent.type, evn.originalEvent));
+				}.bind(this));
 		},
 
 		/**


### PR DESCRIPTION
Fixes: #535 
### Description

Panning stops as soon as the touch zone (25% of the width on each side) is reached.
This PR prevents that.
### How to test
1. Open the slideshow
2. Zoom in all the way
3. Try to pan left or right by dragging from the centre to the edge
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
- [x] iOS9/Safari
### Check list
- [x] Code is properly documented
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@0xb0ba @jancborchardt @setnes @MorrisJobke 
