### PR TITLE
Use Math.ceil() when scaling with devicePixelRatio

### DIFF
--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -88,8 +88,8 @@
 			var start = 0;
 			var images = [];
 			var dir = context.dir + '/';
-			var width = Math.floor(screen.width * window.devicePixelRatio);
-			var height = Math.floor(screen.height * window.devicePixelRatio);
+			var width = Math.ceil(screen.width * window.devicePixelRatio);
+			var height = Math.ceil(screen.height * window.devicePixelRatio);
 
 			/* Find value of longest edge. */
 			var longEdge = Math.max(width, height);

--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -107,8 +107,8 @@ window.Gallery = window.Gallery || {};
 		 * @return {string}
 		 */
 		getPreviewUrl: function (fileId, etag) {
-			var width = Math.floor(screen.width * window.devicePixelRatio);
-			var height = Math.floor(screen.height * window.devicePixelRatio);
+			var width = Math.ceil(screen.width * window.devicePixelRatio);
+			var height = Math.ceil(screen.height * window.devicePixelRatio);
 
 			/* Find value of longest edge. */
 			var longEdge = Math.max(width, height);


### PR DESCRIPTION
Fixes: #484

Licence: Not needed
### Description

Fixed a minor issue. Used `git grep devicePixelRatio` to ensure I got all occurences
### Tested on
- [x] BlackBerry10 / Browser
### Check list
- [x] Code is properly documented
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@jancborchardt @setnes @demattin
