### PR TITLE
[Stable8.2] Restore permission checkboxes

### DIFF
--- a/js/vendor/owncloud/share.js
+++ b/js/vendor/owncloud/share.js
@@ -634,24 +634,49 @@
 					}
 					html += '<label><input type="checkbox" class="checkbox checkbox--right" name="mailNotification" class="mailNotification" ' + checked + ' />'+t('core', 'notify by email')+'</label> ';
 				}
-				if (oc_appconfig.core.resharingAllowed && (possiblePermissions & OC.PERMISSION_SHARE)) {
-					html += '<label><input id="canShare-'+escapeHTML(shareWith)+'" type="checkbox" class="checkbox checkbox--right" name="share" class="permissions" '+shareChecked+' data-permissions="'+OC.PERMISSION_SHARE+'" />'+t('core', 'can share')+'</label>';
+				if (oc_appconfig.core.resharingAllowed &&
+					(possiblePermissions & OC.PERMISSION_SHARE)) {
+					html += '<input id="canShare-' + escapeHTML(shareWith) +
+						'" type="checkbox" class="permissions checkbox checkbox--right" name="share" ' +
+						shareChecked + ' data-permissions="' + OC.PERMISSION_SHARE + '" />';
+					html += '<label for="canShare-' + escapeHTML(shareWith) + '">' +
+						t('core', 'can share') + '</label>';
 				}
-				if (possiblePermissions & OC.PERMISSION_CREATE || possiblePermissions & OC.PERMISSION_UPDATE || possiblePermissions & OC.PERMISSION_DELETE) {
-					html += '<label><input id="canEdit-'+escapeHTML(shareWith)+'" type="checkbox" class="checkbox checkbox--right" name="edit" class="permissions" '+editChecked+' />'+t('core', 'can edit')+'</label>';
+				if (possiblePermissions & OC.PERMISSION_CREATE ||
+					possiblePermissions & OC.PERMISSION_UPDATE ||
+					possiblePermissions & OC.PERMISSION_DELETE) {
+					html += '<input id="canEdit-' + escapeHTML(shareWith) +
+						'" type="checkbox" class="permissions checkbox checkbox--right" name="edit" ' +
+						editChecked + ' />';
+					html += '<label for="canEdit-' + escapeHTML(shareWith) + '">' +
+						t('core', 'can edit') + '</label>';
 				}
-				if (shareType !== OC.Share.SHARE_TYPE_REMOTE) {
-					showCrudsButton = '<a href="#" class="showCruds"><img class="svg" alt="'+t('core', 'access control')+'" src="'+OC.imagePath('core', 'actions/triangle-s')+'"/></a>';
+				if (shareType !== this.SHARE_TYPE_REMOTE) {
+					showCrudsButton = '<a href="#" class="showCruds"><img class="svg" alt="' +
+						t('core', 'access control') + '" src="' +
+						OC.imagePath('core', 'actions/triangle-s') + '"/></a>';
 				}
 				html += '<div class="cruds" style="display:none;">';
 				if (possiblePermissions & OC.PERMISSION_CREATE) {
-					html += '<label><input id="canCreate-' + escapeHTML(shareWith) + '" type="checkbox" class="checkbox checkbox--right" name="create" class="permissions" ' + createChecked + ' data-permissions="' + OC.PERMISSION_CREATE + '"/>' + t('core', 'create') + '</label>';
+					html += '<input id="canCreate-' + escapeHTML(shareWith) +
+						'" type="checkbox" class="permissions checkbox checkbox--right" name="create" ' +
+						createChecked + ' data-permissions="' + OC.PERMISSION_CREATE + '"/>';
+					html += '<label for="canCreate-' + escapeHTML(shareWith) + '">' +
+						t('core', 'create') + '</label>';
 				}
 				if (possiblePermissions & OC.PERMISSION_UPDATE) {
-					html += '<label><input id="canUpdate-' + escapeHTML(shareWith) + '" type="checkbox" class="checkbox checkbox--right" name="update" class="permissions" ' + updateChecked + ' data-permissions="' + OC.PERMISSION_UPDATE + '"/>' + t('core', 'change') + '</label>';
+					html += '<input id="canUpdate-' + escapeHTML(shareWith) +
+						'" type="checkbox" class="permissions checkbox checkbox--right" name="update" ' +
+						updateChecked + ' data-permissions="' + OC.PERMISSION_UPDATE + '"/>';
+					html += '<label for="canUpdate-' + escapeHTML(shareWith) + '">' +
+						t('core', 'change') + '</label>';
 				}
 				if (possiblePermissions & OC.PERMISSION_DELETE) {
-					html += '<label><input id="canDelete-' + escapeHTML(shareWith) + '" type="checkbox" class="checkbox checkbox--right" name="delete" class="permissions" ' + deleteChecked + ' data-permissions="' + OC.PERMISSION_DELETE + '"/>' + t('core', 'delete') + '</label>';
+					html += '<input id="canDelete-' + escapeHTML(shareWith) +
+						'" type="checkbox" class="permissions checkbox checkbox--right" name="delete" ' +
+						deleteChecked + ' data-permissions="' + OC.PERMISSION_DELETE + '"/>';
+					html += '<label for="canDelete-' + escapeHTML(shareWith) + '">' +
+						t('core', 'delete') + '</label>';
 				}
 				html += '</div>';
 				html += '</li>';


### PR DESCRIPTION
Fixes: #538 
### Description

Makes permissions checkboxes visible again
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
### Check list
- [x] Code is properly documented
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@Henni @rullzer @MorrisJobke @PVince81 
