### PR TITLE
#425: Album name is now shown on hovering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -116,6 +116,7 @@ div.crumb.last a {
 }
 
 #gallery .row > a > .album-label {
+	display: inline-block;
 	color: #fff;
 	position: absolute;
 	left: 0;
@@ -129,6 +130,7 @@ div.crumb.last a {
 	overflow-x: hidden;
 	text-overflow: ellipsis;
 	z-index: 11;
+	word-break: break-all;
 }
 
 #gallery .row > a > .image-label {


### PR DESCRIPTION
Fixes:  #425 
### Features
- As in the case of images, now for albums also the album name is shown on hovering over the   thumbnail.
### Screenshots

![gallery2](https://cloud.githubusercontent.com/assets/6432146/13546676/87c806e0-e2db-11e5-9f34-4b124efa2407.png)
![gallery1](https://cloud.githubusercontent.com/assets/6432146/13546677/87ca2f24-e2db-11e5-936f-25aa840b1cd4.png)
### Tested on:
- [x] Ubuntu 14.04/Firefox
- [x] Ubuntu 14/04/Chrome
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@oparoz I have solved #425. Please have a look.

I wanted to ask you that whether I have to add the tests as well?
