### PR TITLE
[stable9] Shared Albums can now be downloaded via shared link, backport of #561

### DIFF
--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -170,7 +170,7 @@ window.Gallery = window.Gallery || {};
 
 			if (Gallery.token) {
 				params.token = Gallery.token;
-				subUrl = 's/{token}/download?path={path}&files={files}';
+				subUrl = 's/{token}/download?dir={path}&files={files}';
 			} else {
 				subUrl = 'apps/files/ajax/download.php?dir={path}&files={files}';
 			}


### PR DESCRIPTION
Fixes: #554 
### Description

There was an error while trying to download when tried through the link shared from inside an album in the gallery. This has been solved now.
### Features

Shared Albums can now be downloaded even from the link shared from inside an album in the gallery.
### Tested on
- [x] Ubuntu 14.04/Firefox
- [x] Ubuntu 14.04/Chrome
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->
1. @oparoz
