### PR TITLE
Wrong galleryimage arguments

### DIFF
--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -294,7 +294,7 @@
 		 */
 		_showFolder: function (targetHeight, imageHolder) {
 			var image = new GalleryImage('Generic folder', 'Generic folder', -1, 'image/svg+xml',
-				Gallery.token);
+			null,null);
 			var thumb = Thumbnails.getStandardIcon(-1);
 			image.thumbnail = thumb;
 			this.images.push(image);


### PR DESCRIPTION
Fixes: #483

Licence: AGPL
### Description

Fixes the Wrong GalleryImage arguments in Album._showFolder.
### Features

Does not affect the previous functioning.
### Tested on
- [x] Ubuntu 14.04/Chrome
### Reviewers

@oparoz 
