### PR TITLE
empty page message is still too low FIX

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -72,7 +72,7 @@ div.crumb.last a {
 	overflow: hidden;
 	text-align: justify;
 	top: 45px;
-	padding-bottom: 100px;
+	padding-bottom: 10px;
 	margin-bottom: 45px;
 	margin-top: 0;
 }


### PR DESCRIPTION
Fixes: _#569_

Licence: AGPL
### Description

Fix for empty page message, which was coming too low
reduced padding-bottom on div#gallery.hascontrols
### Features

Does not alter any features
### Screenshots

![gallery owncloud](https://cloud.githubusercontent.com/assets/6804341/13646995/0ddc9fb4-e658-11e5-9a04-070b4bf57207.png)
![files owncloud](https://cloud.githubusercontent.com/assets/6804341/13646996/10583d84-e658-11e5-9846-024a0924bef6.png)
### Tested on
- [x] Ubuntu14.04/Chrome
### Public Gallery
- does not get effected...working properly
### Logged in Gallery
#### Empty

it is working ok...the message is shifted up in the center...just as in files
#### Half Full

it is working ok...difference is not much noticeable
#### Full

it is working ok...difference is not much noticeable  
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@oparoz
