### PR TITLE
Add uploading support for registered users

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -82,7 +82,10 @@ class PageController extends Controller {
 		$appName = $this->appName;
 
 		// Parameters sent to the template
-		$params = ['appName' => $appName];
+		$params = [
+			'appName' => $appName,
+			'uploadUrl' => $this->urlGenerator->linkTo('files', 'ajax/upload.php')
+		];
 
 		// Will render the page using the template found in templates/index.php
 		$response = new TemplateResponse($appName, 'index', $params);

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -5,4 +5,9 @@
 		margin-right: 0 !important;
 	}
 
+	/* shorten elements for mobile */
+	#uploadprogressbar {
+		width: 50px;
+	}
+
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -286,3 +286,16 @@ http://www.bypeople.com/author/comatosed/*/
 .icon-gallery {
 	background-image: url('../img/gallery-dark.svg');
 }
+
+.oc-dialog .fileexists .icon {
+	background-position: center center;
+	background-size: cover !important;
+}
+
+#uploadprogressbar {
+	margin-top: 5px;
+}
+
+.stop.icon-close {
+	margin-top: 5px;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -286,16 +286,3 @@ http://www.bypeople.com/author/comatosed/*/
 .icon-gallery {
 	background-image: url('../img/gallery-dark.svg');
 }
-
-.oc-dialog .fileexists .icon {
-	background-position: center center;
-	background-size: cover !important;
-}
-
-#uploadprogressbar {
-	margin-top: 5px;
-}
-
-.stop.icon-close {
-	margin-top: 5px;
-}

--- a/css/upload.css
+++ b/css/upload.css
@@ -1,0 +1,95 @@
+/* Uploading */
+.oc-dialog .fileexists .icon {
+	background-position: center center;
+	background-size: cover !important;
+}
+
+#uploadprogressbar {
+	margin-top: 5px;
+}
+
+.stop.icon-close {
+	margin-top: 5px;
+}
+
+.actions {
+	float: left;
+}
+
+.actions input, .actions button, .actions .button {
+	margin: 0;
+	float: left;
+}
+
+.actions .button a {
+	color: #555;
+}
+
+.actions .button a:hover,
+.actions .button a:focus,
+.actions .button a:active {
+	color: #333;
+}
+
+.actions.creatable {
+	position: relative;
+	z-index: -30;
+}
+
+.newFileMenu {
+	width: 140px;
+	margin-left: -56px;
+	margin-top: 25px;
+	z-index: 1001;
+}
+
+.newFileMenu .error {
+	color: #e9322d;
+	border-color: #e9322d;
+	-webkit-box-shadow: 0 0 6px #f8b9b7;
+	-moz-box-shadow: 0 0 6px #f8b9b7;
+	box-shadow: 0 0 6px #f8b9b7;
+}
+
+.newFileMenu .menuitem {
+	white-space: nowrap;
+	overflow: hidden;
+}
+.newFileMenu.popovermenu .menuitem .icon {
+	margin-bottom: -2px;
+}
+.newFileMenu.popovermenu a.menuitem,
+.newFileMenu.popovermenu label.menuitem,
+.newFileMenu.popovermenu .menuitem {
+	padding: 0;
+	margin: 0;
+}
+
+.newFileMenu.popovermenu a.menuitem.active {
+	opacity: 1;
+}
+
+.newFileMenu.bubble:after {
+	left: 75px;
+	right: auto;
+}
+.newFileMenu.bubble:before {
+	left: 75px;
+	right: auto;
+}
+
+.newFileMenu .filenameform {
+	display: inline-block;
+}
+
+.newFileMenu .filenameform input {
+	width: 100px;
+}
+
+#fileList .popovermenu .action {
+	display: block;
+	line-height: 30px;
+	padding-left: 5px;
+	color: #000;
+	padding: 0;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,6 @@
 $(document).ready(function () {
 	"use strict";
 	$('#controls').insertBefore($('#content-wrapper'));
-	Gallery.hideSearch();
 	Gallery.utility = new Gallery.Utility();
 	Gallery.view = new Gallery.View();
 	Gallery.token = Gallery.utility.getPublicToken();
@@ -11,14 +10,14 @@ $(document).ready(function () {
 	// The first thing to do is to detect if we're on IE
 	if (Gallery.ieVersion === 'unsupportedIe') {
 		Gallery.utility.showIeWarning(Gallery.ieVersion);
-		Gallery.showEmpty();
+		Gallery.view.showEmptyFolder('', null);
 	} else {
 		if (Gallery.ieVersion === 'oldIe') {
 			Gallery.utility.showIeWarning(Gallery.ieVersion);
 		}
 
 		// Get the config, the files and initialise the slideshow
-		Gallery.showLoading();
+		Gallery.view.showLoading();
 		$.getJSON(Gallery.utility.buildGalleryUrl('config', '', {}))
 			.then(function (config) {
 				Gallery.config = new Gallery.Config(config);
@@ -26,11 +25,11 @@ $(document).ready(function () {
 				Gallery.getFiles(currentLocation).then(function () {
 					Gallery.activeSlideShow = new SlideShow();
 					$.when(
-							Gallery.activeSlideShow.init(
-								false,
-								null,
-								Gallery.config.galleryFeatures
-							))
+						Gallery.activeSlideShow.init(
+							false,
+							null,
+							Gallery.config.galleryFeatures
+						))
 						.then(function () {
 							window.onhashchange();
 						});
@@ -59,7 +58,7 @@ $(document).ready(function () {
 					Gallery.view.viewAlbum(Gallery.currentAlbum);
 					infoContentContainer.css('max-width', $(window).width());
 				}
-				if(Gallery.currentAlbum) {
+				if (Gallery.currentAlbum) {
 					Gallery.view.breadcrumb.setMaxWidth($(window).width() - Gallery.buttonsWidth);
 				}
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -182,8 +182,7 @@
 
 				var albumPermissions = Gallery.config.albumPermissions;
 				$('a.share').data('path', albumPermissions.path).data('link', true)
-					.data('possible-permissions', albumPermissions.permissions).
-					click();
+					.data('possible-permissions', albumPermissions.permissions).click();
 				if (!$('#linkCheckbox').is(':checked')) {
 					$('#linkText').hide();
 				}
@@ -329,6 +328,7 @@
 			var mTime = null;
 			var etag = null;
 			var size = null;
+			var sharedWithUser = null;
 			var albumInfo = data.albuminfo;
 			var currentLocation = albumInfo.path;
 			// This adds a new node to the map for each parent album
@@ -345,8 +345,12 @@
 					mTime = files[i].mtime;
 					etag = files[i].etag;
 					size = files[i].size;
+					sharedWithUser = files[i].sharedWithUser;
 
-					image = new GalleryImage(path, path, fileId, mimeType, mTime, etag, size);
+					image =
+						new GalleryImage(
+							path, path, fileId, mimeType, mTime, etag, size, sharedWithUser
+						);
 
 					// Determines the folder name for the image
 					var dir = OC.dirname(path);

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -3,6 +3,7 @@
 	"use strict";
 	var Gallery = {
 		currentAlbum: null,
+		currentEtag: null,
 		config: {},
 		/** Map of the whole gallery, built as we navigate through folders */
 		albumMap: {},
@@ -379,6 +380,7 @@
 			var mimeType = null;
 			var mTime = null;
 			var etag = null;
+			var size = null;
 			var albumInfo = data.albuminfo;
 			var currentLocation = albumInfo.path;
 			// This adds a new node to the map for each parent album
@@ -394,8 +396,9 @@
 					mimeType = files[i].mimetype;
 					mTime = files[i].mtime;
 					etag = files[i].etag;
+					size = files[i].size;
 
-					image = new GalleryImage(path, path, fileId, mimeType, mTime, etag);
+					image = new GalleryImage(path, path, fileId, mimeType, mTime, etag, size);
 
 					// Determines the folder name for the image
 					var dir = OC.dirname(path);

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -23,7 +23,7 @@
 		 */
 		refresh: function (path, albumPath) {
 			if (Gallery.currentAlbum !== albumPath) {
-				Gallery.view.init(albumPath);
+				Gallery.view.init(albumPath, null);
 			}
 
 			// If the path is mapped, that means that it's an albumPath
@@ -90,11 +90,9 @@
 					Gallery.config.updateAlbumSorting(Gallery.albumMap[albumInfo.path].sorting);
 				}
 
-			}, function () {
-				// Triggered if we couldn't find a working folder
-				Gallery.view.element.empty();
-				Gallery.showEmpty();
-				Gallery.currentAlbum = null;
+			}, function (xhr) {
+				var result = xhr.responseJSON;
+				Gallery.view.init(decodeURIComponent(currentLocation), result.message);
 			});
 		},
 
@@ -131,8 +129,9 @@
 			// Sort the images
 			Gallery.albumMap[Gallery.currentAlbum].images.sort(Gallery.utility.sortBy(sortType,
 				sortOrder));
-			Gallery.albumMap[Gallery.currentAlbum].subAlbums.sort(Gallery.utility.sortBy(albumSortType,
-				albumSortOrder));
+			Gallery.albumMap[Gallery.currentAlbum].subAlbums.sort(
+				Gallery.utility.sortBy(albumSortType,
+					albumSortOrder));
 
 			// Save the new settings
 			var sortConfig = {
@@ -242,58 +241,6 @@
 		},
 
 		/**
-		 * Hide the search button while we wait for core to fix the templates
-		 */
-		hideSearch: function () {
-			$('form.searchbox').hide();
-		},
-
-		/**
-		 * Shows an empty gallery message
-		 */
-		showEmpty: function () {
-			var emptyContentElement = $('#emptycontent');
-			var message = '<div class="icon-gallery"></div>';
-			message += '<h2>' + t('gallery',
-				'No pictures found') + '</h2>';
-			message += '<p>' + t('gallery',
-				'Upload pictures in the files app to display them here') + '</p>';
-			emptyContentElement.html(message);
-			emptyContentElement.removeClass('hidden');
-			$('#controls').addClass('hidden');
-		},
-
-		/**
-		 * Shows an empty gallery message
-		 */
-		showEmptyFolder: function () {
-			var emptyContentElement = $('#emptycontent');
-			var message = '<div class="icon-gallery"></div>';
-			message += '<h2>' + t('gallery',
-				'Nothing in here') + '</h2>';
-			message += '<p>' + t('gallery',
-				'No media files found in this folder') + '</p>';
-			emptyContentElement.html(message);
-			emptyContentElement.removeClass('hidden');
-		},
-
-		/**
-		 * Shows the infamous loading spinner
-		 */
-		showLoading: function () {
-			$('#emptycontent').addClass('hidden');
-			$('#controls').removeClass('hidden');
-		},
-
-		/**
-		 * Shows thumbnails
-		 */
-		showNormal: function () {
-			$('#emptycontent').addClass('hidden');
-			$('#controls').removeClass('hidden');
-		},
-
-		/**
 		 * Creates a new slideshow using the images found in the current folder
 		 *
 		 * @param {Array} images
@@ -328,7 +275,8 @@
 					c: image.etag,
 					requesttoken: oc_requesttoken
 				};
-				var downloadUrl = Gallery.utility.buildGalleryUrl('files', '/download/' + image.fileId,
+				var downloadUrl = Gallery.utility.buildGalleryUrl('files',
+					'/download/' + image.fileId,
 					params);
 
 				return {
@@ -508,15 +456,15 @@
 				// directive
 				$.get(OC.generateUrl('apps/files_sharing/testremote'),
 					{remote: remote}).then(function (protocol) {
-						if (protocol !== 'http' && protocol !== 'https') {
-							OC.dialogs.alert(t('files_sharing',
-									'No ownCloud installation (7 or higher) found at {remote}',
-									{remote: remote}),
-								t('files_sharing', 'Invalid ownCloud url'));
-						} else {
-							OC.redirect(protocol + '://' + url);
-						}
-					});
+					if (protocol !== 'http' && protocol !== 'https') {
+						OC.dialogs.alert(t('files_sharing',
+							'No ownCloud installation (7 or higher) found at {remote}',
+							{remote: remote}),
+							t('files_sharing', 'Invalid ownCloud url'));
+					} else {
+						OC.redirect(protocol + '://' + url);
+					}
+				});
 			}
 		}
 	};

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -14,21 +14,23 @@
 	/**
 	 * Creates a new image object to store information about a media file
 	 *
-	 * @param src
-	 * @param path
-	 * @param fileId
-	 * @param mimeType
-	 * @param mTime modification time
-	 * @param etag
+	 * @param {string} src
+	 * @param {string} path
+	 * @param {number} fileId
+	 * @param {string} mimeType
+	 * @param {number} mTime modification time
+	 * @param {string} etag
+	 * @param {number} size
 	 * @constructor
 	 */
-	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag) {
+	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag, size) {
 		this.src = src;
 		this.path = path;
 		this.fileId = fileId;
 		this.mimeType = mimeType;
 		this.mTime = mTime;
 		this.etag = etag;
+		this.size = size;
 		this.thumbnail = null;
 		this.domDef = null;
 		this.spinner = null;

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -21,9 +21,10 @@
 	 * @param {number} mTime modification time
 	 * @param {string} etag
 	 * @param {number} size
+	 * @param {boolean} sharedWithUser
 	 * @constructor
 	 */
-	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag, size) {
+	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag, size, sharedWithUser) {
 		this.src = src;
 		this.path = path;
 		this.fileId = fileId;
@@ -31,6 +32,7 @@
 		this.mTime = mTime;
 		this.etag = etag;
 		this.size = size;
+		this.sharedWithUser = sharedWithUser;
 		this.thumbnail = null;
 		this.domDef = null;
 		this.spinner = null;

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -272,6 +272,23 @@
 					});
 				}
 			});
+
+			// Since 9.0
+			if (OC.Upload) {
+				OC.Upload._isReceivedSharedFile = function (file) {
+					var path = file.name;
+					var sharedWith = false;
+
+					if (Gallery.currentAlbum !== '' && Gallery.currentAlbum !== '/') {
+						path = Gallery.currentAlbum + '/' + path;
+					}
+					if (Gallery.imageMap[path] && Gallery.imageMap[path].sharedWithUser) {
+						sharedWith = true;
+					}
+
+					return sharedWith;
+				};
+			}
 		},
 
 		/**

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -9,6 +9,7 @@
 	var View = function () {
 		this.element = $('#gallery');
 		this.loadVisibleRows.loading = false;
+		this._setupUploader();
 		this.breadcrumb = new Gallery.Breadcrumb();
 	};
 
@@ -82,9 +83,10 @@
 
 			this.clear();
 
-			if (albumPath !== Gallery.currentAlbum) {
+			if (Gallery.albumMap[albumPath].etag !== Gallery.currentEtag) {
 				this.loadVisibleRows.loading = false;
 				Gallery.currentAlbum = albumPath;
+				Gallery.currentEtag = Gallery.albumMap[albumPath].etag;
 				this._setupButtons(albumPath);
 			}
 
@@ -199,6 +201,29 @@
 			$('#share-button').hide();
 			$('#sort-name-button').hide();
 			$('#sort-date-button').hide();
+		},
+
+		/**
+		 * Sets up our custom handlers for folder uploading operations
+		 *
+		 * We only want it to be called for that specific case as all other file uploading
+		 * operations will call Files.highlightFiles
+		 *
+		 * @see OC.Upload.init/file_upload_param.done()
+		 *
+		 * @private
+		 */
+		_setupUploader: function () {
+			$('#file_upload_start').on('fileuploaddone', function (e, data) {
+				if (data.files[0] === data.originalFiles[data.originalFiles.length - 1]
+					&& data.files[0].relativePath) {
+
+					//Ask for a refresh of the photowall
+					Gallery.getFiles(Gallery.currentAlbum).done(function () {
+						Gallery.view.init(Gallery.currentAlbum);
+					});
+				}
+			});
 		},
 
 		/**

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -90,7 +90,7 @@ function Thumbnail (fileId, square) {
 		 */
 		loadBatch: function (ids, square) {
 			var map = (square) ? Thumbnails.squareMap : Thumbnails.map;
-			// Purely here as a precaution
+			// Prevents re-loading thumbnails when resizing the window
 			ids = ids.filter(function (id) {
 				return !map[id];
 			});

--- a/js/upload-helper.js
+++ b/js/upload-helper.js
@@ -1,0 +1,164 @@
+/* global Gallery, Thumbnails */
+/**
+ * OCA.FileList methods needed for file uploading
+ *
+ * This hack makes it possible to use the Files scripts as is, without having to import and
+ * maintain them in Gallery
+ *
+ * Empty methods are for the "new" button, if we want to implement that one day
+ *
+ * @type {{inList: FileList.inList, lastAction: FileList.lastAction, getUniqueName:
+ *     FileList.getUniqueName, getCurrentDirectory: FileList.getCurrentDirectory, add:
+ *     FileList.add, checkName: FileList.checkName}}
+ */
+var FileList = {
+	/**
+	 * Makes sure the filename does not exist
+	 *
+	 * Gives an early chance to the user to abort the action, before uploading everything to the
+	 * server.
+	 * Albums are not supported as we don't have a full list of images contained in a sub-album
+	 *
+	 * @param fileName
+	 * @returns {*}
+	 */
+	findFile: function (fileName) {
+		"use strict";
+		var path = Gallery.currentAlbum + '/' + fileName;
+		var galleryImage = Gallery.imageMap[path];
+		if (galleryImage) {
+			var fileInfo = {
+				name: fileName,
+				directory: Gallery.currentAlbum,
+				path: path,
+				etag: galleryImage.etag,
+				mtime: galleryImage.mTime * 1000, // Javascript gives the Epoch time in milliseconds
+				size: galleryImage.size
+			};
+			return fileInfo;
+		} else {
+			return null;
+		}
+	},
+
+	/**
+	 * Refreshes the photowall
+	 *
+	 * Called at the end of the uploading process when 1 or multiple files are sent
+	 * Never called with folders on Chrome, unless files are uploaded at the same time as folders
+	 *
+	 * @param fileList
+	 */
+	highlightFiles: function (fileList) {
+		"use strict";
+		//Ask for a refresh of the photowall
+		Gallery.getFiles(Gallery.currentAlbum).done(function () {
+			var fileId, path;
+			// Removes the cached thumbnails of files which have been re-uploaded
+			_(fileList).each(function (fileName) {
+				path = Gallery.currentAlbum + '/' + fileName;
+				if (Gallery.imageMap[path]) {
+					fileId = Gallery.imageMap[path].fileId;
+					if (Thumbnails.map[fileId]) {
+						delete Thumbnails.map[fileId];
+					}
+				}
+			});
+
+			Gallery.view.init(Gallery.currentAlbum);
+		});
+	},
+
+	/**
+	 * Retrieves the current album
+	 *
+	 * @returns {string}
+	 */
+	getCurrentDirectory: function () {
+		"use strict";
+
+		// In Files, dirs start with a /
+		return '/' + Gallery.currentAlbum;
+	},
+	inList: function (filename) {
+		"use strict";
+
+	},
+	lastAction: function () {
+		"use strict";
+
+	},
+	getUniqueName: function (newname) {
+		"use strict";
+
+	},
+	add: function (fileData, options) {
+		"use strict";
+
+	},
+	checkName: function (name, newname, bool) {
+		"use strict";
+
+	}
+};
+
+/**
+ * OCA.Files methods needed for file uploading
+ *
+ * This hack makes it possible to use the Files scripts as is, without having to import and
+ * maintain them in Gallery
+ *
+ * @type {{isFileNameValid: Files.isFileNameValid, generatePreviewUrl: Files.generatePreviewUrl}}
+ */
+var Files = {
+	App: {fileList: {}},
+
+	isFileNameValid: function (name) {
+		"use strict";
+		var trimmedName = name.trim();
+		if (trimmedName === '.' || trimmedName === '..') {
+			throw t('files', '"{name}" is an invalid file name.', {name: name});
+		} else if (trimmedName.length === 0) {
+			throw t('files', 'File name cannot be empty.');
+		}
+		return true;
+
+	},
+
+	/**
+	 * Generates a preview for the conflict dialogue
+	 *
+	 * Since Gallery uses the fileId and Files uses the path, we have to use the preview endpoint
+	 * of Files
+	 */
+	generatePreviewUrl: function (urlSpec) {
+		"use strict";
+		var previewUrl;
+		var path = urlSpec.file;
+
+		// In Files, root files start with //
+		if (path.indexOf('//') === 0) {
+			path = path.substring(2);
+		} else {
+			// Directories start with /
+			path = path.substring(1);
+		}
+
+		if (Gallery.imageMap[path]) {
+			var fileId = Gallery.imageMap[path].fileId;
+			var thumbnail = Thumbnails.map[fileId];
+			previewUrl = thumbnail.image.src;
+		} else {
+			var previewDimension = 96;
+			urlSpec.x = Math.ceil(previewDimension * window.devicePixelRatio);
+			urlSpec.y = Math.ceil(previewDimension * window.devicePixelRatio);
+			urlSpec.forceIcon = 0;
+			previewUrl = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
+		}
+
+		return previewUrl;
+	}
+};
+
+OCA.Files = Files;
+OCA.Files.App.fileList = FileList;

--- a/js/upload-helper.js
+++ b/js/upload-helper.js
@@ -79,26 +79,6 @@ var FileList = {
 
 		// In Files, dirs start with a /
 		return '/' + Gallery.currentAlbum;
-	},
-	inList: function (filename) {
-		"use strict";
-
-	},
-	lastAction: function () {
-		"use strict";
-
-	},
-	getUniqueName: function (newname) {
-		"use strict";
-
-	},
-	add: function (fileData, options) {
-		"use strict";
-
-	},
-	checkName: function (name, newname, bool) {
-		"use strict";
-
 	}
 };
 

--- a/js/vendor/owncloud/newfilemenu.js
+++ b/js/vendor/owncloud/newfilemenu.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2014-2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING file.
+ *
+ */
+
+/* global Handlebars, Gallery */
+(function ($, Gallery) {
+	"use strict";
+	var TEMPLATE_MENU =
+		'<ul>' +
+		'<li>' +
+		'<label for="file_upload_start" class="menuitem" data-action="upload" title="{{uploadMaxHumanFilesize}}"><span class="svg icon icon-upload"></span><span class="displayname">{{uploadLabel}}</span></label>' +
+		'</li>' +
+		'</ul>';
+
+	/**
+	 * Construct a new NewFileMenu instance
+	 * @constructs NewFileMenu
+	 *
+	 * @memberof Gallery
+	 */
+	var NewFileMenu = OC.Backbone.View.extend({
+		tagName: 'div',
+		className: 'newFileMenu popovermenu bubble hidden open menu',
+
+		events: {
+			'click .menuitem': '_onClickAction'
+		},
+
+		initialize: function () {
+			var self = this;
+			var $uploadEl = $('#file_upload_start');
+			if ($uploadEl.length) {
+				$uploadEl.on('fileuploadstart', function () {
+					self.trigger('actionPerformed', 'upload');
+				});
+			} else {
+				console.warn('Missing upload element "file_upload_start"');
+			}
+		},
+
+		template: function (data) {
+			if (!Gallery.NewFileMenu._TEMPLATE) {
+				Gallery.NewFileMenu._TEMPLATE = Handlebars.compile(TEMPLATE_MENU);
+			}
+			return Gallery.NewFileMenu._TEMPLATE(data);
+		},
+
+		/**
+		 * Event handler whenever the upload button has been clicked within the menu
+		 */
+		_onClickAction: function () {
+			// note: clicking the upload label will automatically
+			// set the focus on the "file_upload_start" hidden field
+			// which itself triggers the upload dialog.
+			// Currently the upload logic is still in file-upload.js and filelist.js
+			OC.hideMenus();
+		},
+
+		/**
+		 * Renders the menu with the currently set items
+		 */
+		render: function () {
+			this.$el.html(this.template({
+				uploadMaxHumanFileSize: 'TODO',
+				uploadLabel: t('gallery', 'Upload')
+			}));
+		},
+
+		/**
+		 * Displays the menu under the given element
+		 *
+		 * @param {Object} $target target element
+		 */
+		showAt: function ($target) {
+			this.render();
+			var targetOffset = $target.offset();
+			this.$el.css({
+				left: targetOffset.left,
+				top: targetOffset.top + $target.height()
+			});
+			this.$el.removeClass('hidden');
+
+			OC.showMenu(null, this.$el);
+		}
+	});
+
+	Gallery.NewFileMenu = NewFileMenu;
+})(jQuery, Gallery);

--- a/service/configservice.php
+++ b/service/configservice.php
@@ -169,7 +169,9 @@ class ConfigService extends FilesService {
 		list ($albumConfig, $privateAlbum) =
 			$this->getAlbumConfig($folderNode, $this->privacyChecker, $this->configName);
 		if ($privateAlbum) {
-			throw new ForbiddenServiceException('Album is private or unavailable');
+			throw new ForbiddenServiceException(
+				'The owner has placed a restriction or the storage location is unavailable'
+			);
 		}
 		$albumInfo = [
 			'path'        => $folderPathFromRoot,

--- a/service/configservice.php
+++ b/service/configservice.php
@@ -174,10 +174,11 @@ class ConfigService extends FilesService {
 			);
 		}
 		$albumInfo = [
-			'path'        => $folderPathFromRoot,
-			'fileid'      => $folderNode->getID(),
-			'permissions' => $folderNode->getPermissions(),
-			'etag'        => $folderNode->getEtag()
+			'path'           => $folderPathFromRoot,
+			'fileid'         => $folderNode->getId(),
+			'permissions'    => $folderNode->getPermissions(),
+			'etag'           => $folderNode->getEtag(),
+			'sharedWithUser' => $folderNode->isShared()
 		];
 		// There is always an albumInfo, but the albumConfig may be empty
 		$albumConfig = array_merge($albumInfo, $albumConfig);

--- a/service/searchfolderservice.php
+++ b/service/searchfolderservice.php
@@ -30,7 +30,7 @@ class SearchFolderService extends FilesService {
 	 * @var int
 	 */
 	protected $virtualRootLevel = null;
-	
+
 	/**
 	 * This returns what we think is the current folder node based on a given path
 	 *
@@ -126,7 +126,9 @@ class SearchFolderService extends FilesService {
 			// Something very wrong has just happened
 			throw new NotFoundServiceException('Oh Nooooes!');
 		} elseif (!$this->isAllowedAndAvailable($node)) {
-			throw new ForbiddenServiceException('Album is private or unavailable');
+			throw new ForbiddenServiceException(
+				'The owner has placed a restriction or the storage location is unavailable'
+			);
 		}
 
 		return [$path, $node, $locationHasChanged];

--- a/service/searchmediaservice.php
+++ b/service/searchmediaservice.php
@@ -202,13 +202,15 @@ class SearchMediaService extends FilesService {
 		$mimeType = $file->getMimetype();
 		$mTime = $file->getMTime();
 		$etag = $file->getEtag();
+		$size = $file->getSize();
 
 		$imageData = [
 			'path'     => $imagePath,
 			'fileid'   => $imageId,
 			'mimetype' => $mimeType,
 			'mtime'    => $mTime,
-			'etag'     => $etag
+			'etag'     => $etag,
+			'size'     => $size
 		];
 
 		$this->images[] = $imageData;

--- a/service/searchmediaservice.php
+++ b/service/searchmediaservice.php
@@ -199,18 +199,20 @@ class SearchMediaService extends FilesService {
 	private function addFileToResults($file) {
 		$imagePath = $this->environment->getPathFromVirtualRoot($file);
 		$imageId = $file->getId();
-		$mimeType = $file->getMimetype();
+		$mimeType = $file->getMimeType();
 		$mTime = $file->getMTime();
 		$etag = $file->getEtag();
 		$size = $file->getSize();
+		$sharedWithUser = $file->isShared();
 
 		$imageData = [
-			'path'     => $imagePath,
-			'fileid'   => $imageId,
-			'mimetype' => $mimeType,
-			'mtime'    => $mTime,
-			'etag'     => $etag,
-			'size'     => $size
+			'path'           => $imagePath,
+			'fileid'         => $imageId,
+			'mimetype'       => $mimeType,
+			'mtime'          => $mTime,
+			'etag'           => $etag,
+			'size'           => $size,
+			'sharedWithUser' => $sharedWithUser
 		];
 
 		$this->images[] = $imageData;

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -41,23 +41,22 @@ script(
 		'jquery.iframe-transport'
 	]
 );
-
+style(
+	'files',
+	[
+		'upload'
+	]
+);
 style(
 	$_['appName'],
 	[
 		'styles',
 		'share',
-		'mobile',
 		'github-markdown',
 		'slideshow',
 		'gallerybutton',
-		'upload'
-	]
-);
-style(
-	'files',
-	[
-		'upload'
+		'upload',
+		'mobile',
 	]
 );
 ?>

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -27,9 +27,20 @@ script(
 		'vendor/bigshot/bigshot-compressed',
 		'slideshow',
 		'slideshowcontrols',
-		'slideshowzoomablepreview'
+		'slideshowzoomablepreview',
+		'upload-helper'
 	]
 );
+script(
+	'files',
+	[
+		'upload',
+		'file-upload',
+		'jquery.fileupload',
+		'jquery.iframe-transport'
+	]
+);
+
 style(
 	$_['appName'],
 	[
@@ -39,6 +50,12 @@ style(
 		'github-markdown',
 		'slideshow',
 		'gallerybutton'
+	]
+);
+style(
+	'files',
+	[
+		'upload'
 	]
 );
 ?>
@@ -66,6 +83,14 @@ style(
 				); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
 			</div>
 		</div>
+	</div>
+	<div id="uploadprogresswrapper">
+		<div id="uploadprogressbar"></div>
+		<button class="stop icon-close" style="display:none">
+			<span class="hidden-visually">
+				<?php p($l->t('Cancel upload')) ?>
+			</span>
+		</button>
 	</div>
 	<span class="right">
 		<!-- sharing button -->
@@ -100,3 +125,7 @@ style(
 <div id="gallery" class="hascontrols"></div>
 <div id="emptycontent" class="hidden"></div>
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
+<div class="hiddenuploadfield">
+	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"
+		   data-url="<?php print_unescaped($_['uploadUrl']); ?>"/>
+</div>

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -28,7 +28,8 @@ script(
 		'slideshow',
 		'slideshowcontrols',
 		'slideshowzoomablepreview',
-		'upload-helper'
+		'upload-helper',
+		'vendor/owncloud/newfilemenu'
 	]
 );
 script(
@@ -49,7 +50,8 @@ style(
 		'mobile',
 		'github-markdown',
 		'slideshow',
-		'gallerybutton'
+		'gallerybutton',
+		'upload'
 	]
 );
 style(
@@ -84,14 +86,17 @@ style(
 			</div>
 		</div>
 	</div>
-	<div id="uploadprogresswrapper">
-		<div id="uploadprogressbar"></div>
-		<button class="stop icon-close" style="display:none">
+	<div class="actions creatable">
+		<div id="uploadprogresswrapper">
+			<div id="uploadprogressbar"></div>
+			<button class="stop icon-close" style="display:none">
 			<span class="hidden-visually">
 				<?php p($l->t('Cancel upload')) ?>
 			</span>
-		</button>
+			</button>
+		</div>
 	</div>
+	<div id="file_action_panel"></div>
 	<span class="right">
 		<!-- sharing button -->
 		<div id="share-button" class="button">

--- a/tests/api/GetFilesCest.php
+++ b/tests/api/GetFilesCest.php
@@ -142,7 +142,10 @@ class GetFilesCest {
 		$I->seeResponseCodeIs($statusCode);
 		$I->seeResponseIsJson();
 		$I->seeResponseContainsJson(
-			['message' => 'Album is private or unavailable (' . $statusCode . ')']
+			[
+				'message' => 'The owner has placed a restriction or the storage location is unavailable ('
+							 . $statusCode . ')'
+			]
 		);
 	}
 

--- a/tests/unit/GalleryUnitTest.php
+++ b/tests/unit/GalleryUnitTest.php
@@ -93,7 +93,9 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 	 *
 	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
-	protected function mockFile($fileId, $storageId = 'home::user', $isReadable = true, $path = ''
+	protected function mockFile(
+		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024
 	) {
 		$storage = $this->mockGetStorage($storageId);
 		$file = $this->getMockBuilder('OCP\Files\File')
@@ -109,12 +111,19 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 			 ->willReturn($isReadable);
 		$file->method('getPath')
 			 ->willReturn($path);
+		$file->method('getEtag')
+			 ->willReturn($etag);
+		$file->method('getSize')
+			 ->willReturn($size);
 
 		return $file;
 	}
 
-	protected function mockJpgFile($fileId) {
-		$file = $this->mockFile($fileId);
+	protected function mockJpgFile(
+		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024
+	) {
+		$file = $this->mockFile($fileId, $storageId, $isReadable, $path, $etag, $size);
 		$this->mockJpgFileMethods($file);
 
 		return $file;

--- a/tests/unit/GalleryUnitTest.php
+++ b/tests/unit/GalleryUnitTest.php
@@ -90,12 +90,15 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 	 * @param string $storageId
 	 * @param bool $isReadable
 	 * @param string $path
+	 * @param string $etag
+	 * @param int $size
+	 * @param bool $isShared
 	 *
 	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function mockFile(
 		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
-		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024, $isShared = false
 	) {
 		$storage = $this->mockGetStorage($storageId);
 		$file = $this->getMockBuilder('OCP\Files\File')
@@ -115,15 +118,17 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 			 ->willReturn($etag);
 		$file->method('getSize')
 			 ->willReturn($size);
+		$file->method('isShared')
+			 ->willReturn($isShared);
 
 		return $file;
 	}
 
 	protected function mockJpgFile(
 		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
-		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024, $isShared = false
 	) {
-		$file = $this->mockFile($fileId, $storageId, $isReadable, $path, $etag, $size);
+		$file = $this->mockFile($fileId, $storageId, $isReadable, $path, $etag, $size, $isShared);
 		$this->mockJpgFileMethods($file);
 
 		return $file;

--- a/tests/unit/controller/FilesControllerTest.php
+++ b/tests/unit/controller/FilesControllerTest.php
@@ -169,6 +169,7 @@ class FilesControllerTest extends \Test\GalleryUnitTest {
 		$folderId = 9876;
 		$folderPermissions = 31;
 		$folderEtag = 9999888877776666;
+		$folderIsShared = false;
 		$files = [
 			['path' => $folderPathFromRoot . '/deep/path.png'],
 			['path' => $folderPathFromRoot . '/testimage.png']
@@ -177,7 +178,8 @@ class FilesControllerTest extends \Test\GalleryUnitTest {
 			'path'        => $folderPathFromRoot,
 			'fileid'      => $folderId,
 			'permissions' => $folderPermissions,
-			'etag'        => $folderEtag
+			'etag'        => $folderEtag,
+			'shared'      => $folderIsShared
 		];
 		$locationHasChanged = false;
 		$result = [
@@ -185,7 +187,9 @@ class FilesControllerTest extends \Test\GalleryUnitTest {
 			'albuminfo'          => $albumInfo,
 			'locationhaschanged' => $locationHasChanged
 		];
-		$folder = $this->mockGetFolder($folderId, $files, $folderPermissions, $folderEtag);
+		$folder = $this->mockGetFolder(
+			$folderId, $files, $folderPermissions, $folderEtag, $folderIsShared
+		);
 
 		$this->mockGetCurrentFolder(
 			$location, $folderPathFromRoot, [$features], $locationHasChanged, $folder
@@ -351,7 +355,7 @@ class FilesControllerTest extends \Test\GalleryUnitTest {
 								  ->willReturn($answer);
 	}
 
-	private function mockGetFolder($nodeId, $files, $permissions, $etag) {
+	private function mockGetFolder($nodeId, $files, $permissions, $etag, $isShared) {
 		$folder = $this->getMockBuilder('OCP\Files\Folder')
 					   ->disableOriginalConstructor()
 					   ->getMock();
@@ -365,6 +369,8 @@ class FilesControllerTest extends \Test\GalleryUnitTest {
 			   ->willReturn($permissions);
 		$folder->method('getEtag')
 			   ->willReturn($etag);
+		$folder->method('isShared')
+			   ->willReturn($isShared);
 
 		return $folder;
 	}

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -69,7 +69,12 @@ class PageControllerTest extends \Test\TestCase {
 
 
 	public function testIndex() {
-		$params = ['appName' => $this->appName];
+		$url = 'http://owncloud/ajax/upload.php';
+		$this->mockUrlToUploadEndpoint($url);
+		$params = [
+			'appName' => $this->appName,
+			'uploadUrl' => $url
+		];
 		$template = new TemplateResponse($this->appName, 'index', $params);
 
 		$response = $this->controller->index();
@@ -239,4 +244,10 @@ class PageControllerTest extends \Test\TestCase {
 					  ->willReturn($value);
 	}
 
+	private function mockUrlToUploadEndpoint($url) {
+		$this->urlGenerator->expects($this->once())
+						   ->method('linkTo')
+						   ->with('files', 'ajax/upload.php')
+						   ->willReturn($url);
+	}
 }

--- a/tests/unit/service/SearchFolderServiceTest.php
+++ b/tests/unit/service/SearchFolderServiceTest.php
@@ -105,7 +105,9 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 	 */
 	public function testSendExternalFolder($storageId) {
 		$expectedException =
-			new ForbiddenServiceException('Album is private or unavailable');
+			new ForbiddenServiceException(
+				'The owner has placed a restriction or the storage location is unavailable'
+			);
 		$path = '';
 		$nodeId = 94875;
 		$files = [];

--- a/tests/unit/service/SearchMediaServiceTest.php
+++ b/tests/unit/service/SearchMediaServiceTest.php
@@ -205,6 +205,68 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$this->assertSame($result, sizeof($response));
 	}
 
+	public function providesFolderWithFilesData() {
+		$isReadable = true;
+		$mounted = false;
+		$mount = null;
+		$query = '.nomedia';
+		$queryResult = false;
+
+		$file1 = [
+			'fileid'     => 11111,
+			'storageId'  => 'home::user',
+			'isReadable' => true,
+			'path'       => null,
+			'etag'       => "8603c11cd6c5d739f2c156c38b8db8c4",
+			'size'       => 1024,
+			'mimetype'   => 'image/jpeg'
+		];
+
+
+		$folder1 = $this->mockFolder(
+			'home::user', 545454, [
+			$this->mockJpgFile(
+				$file1['fileid'], $file1['storageId'], $file1['isReadable'], $file1['path'],
+				$file1['etag'], $file1['size']
+			)
+		], $isReadable, $mounted, $mount, $query, $queryResult
+		);
+
+		return [
+			[
+				$folder1, [
+				[
+					'path'     => $file1['path'],
+					'fileid'   => $file1['fileid'],
+					'mimetype' => $file1['mimetype'],
+					'mtime'    => null,
+					'etag'     => $file1['etag'],
+					'size'     => $file1['size']
+				]
+			]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider providesFolderWithFilesData
+	 *
+	 * @param array $topFolder
+	 * @param int $result
+	 */
+	public function testPropertiesOfGetMediaFiles($topFolder, $result) {
+		$supportedMediaTypes = [
+			'image/png',
+			'image/jpeg',
+			'image/gif'
+		];
+		$features = [];
+
+		$response = $this->service->getMediaFiles($topFolder, $supportedMediaTypes, $features);
+
+		$this->assertSame($result, $response);
+	}
+
 	/**
 	 * @expectedException \OCA\Gallery\Service\NotFoundServiceException
 	 */

--- a/tests/unit/service/SearchMediaServiceTest.php
+++ b/tests/unit/service/SearchMediaServiceTest.php
@@ -12,6 +12,8 @@
 
 namespace OCA\Gallery\Service;
 
+use OCP\Files\Folder;
+
 /**
  * Class SearchMediaServiceTest
  *
@@ -189,7 +191,7 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 	/**
 	 * @dataProvider providesTopFolderData
 	 *
-	 * @param array $topFolder
+	 * @param Folder $topFolder
 	 * @param int $result
 	 */
 	public function testGetMediaFiles($topFolder, $result) {
@@ -213,13 +215,25 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$queryResult = false;
 
 		$file1 = [
-			'fileid'     => 11111,
-			'storageId'  => 'home::user',
-			'isReadable' => true,
-			'path'       => null,
-			'etag'       => "8603c11cd6c5d739f2c156c38b8db8c4",
-			'size'       => 1024,
-			'mimetype'   => 'image/jpeg'
+			'fileid'         => 11111,
+			'storageId'      => 'home::user',
+			'isReadable'     => true,
+			'path'           => null,
+			'etag'           => "8603c11cd6c5d739f2c156c38b8db8c4",
+			'size'           => 1024,
+			'sharedWithUser' => false,
+			'mimetype'       => 'image/jpeg'
+		];
+
+		$file2 = [
+			'fileid'         => 22222,
+			'storageId'      => 'webdav::user@domain.com/dav',
+			'isReadable'     => true,
+			'path'           => null,
+			'etag'           => "739f2c156c38b88603c11cd6c5ddb8c4",
+			'size'           => 102410241024,
+			'sharedWithUser' => true,
+			'mimetype'       => 'image/jpeg'
 		];
 
 
@@ -227,7 +241,11 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			'home::user', 545454, [
 			$this->mockJpgFile(
 				$file1['fileid'], $file1['storageId'], $file1['isReadable'], $file1['path'],
-				$file1['etag'], $file1['size']
+				$file1['etag'], $file1['size'], $file1['sharedWithUser']
+			),
+			$this->mockJpgFile(
+				$file2['fileid'], $file2['storageId'], $file2['isReadable'], $file2['path'],
+				$file2['etag'], $file2['size'], $file2['sharedWithUser']
 			)
 		], $isReadable, $mounted, $mount, $query, $queryResult
 		);
@@ -236,12 +254,22 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			[
 				$folder1, [
 				[
-					'path'     => $file1['path'],
-					'fileid'   => $file1['fileid'],
-					'mimetype' => $file1['mimetype'],
-					'mtime'    => null,
-					'etag'     => $file1['etag'],
-					'size'     => $file1['size']
+					'path'           => $file1['path'],
+					'fileid'         => $file1['fileid'],
+					'mimetype'       => $file1['mimetype'],
+					'mtime'          => null,
+					'etag'           => $file1['etag'],
+					'size'           => $file1['size'],
+					'sharedWithUser' => $file1['sharedWithUser']
+				],
+				[
+					'path'           => $file2['path'],
+					'fileid'         => $file2['fileid'],
+					'mimetype'       => $file2['mimetype'],
+					'mtime'          => null,
+					'etag'           => $file2['etag'],
+					'size'           => $file2['size'],
+					'sharedWithUser' => $file2['sharedWithUser']
 				]
 			]
 			]
@@ -251,8 +279,8 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 	/**
 	 * @dataProvider providesFolderWithFilesData
 	 *
-	 * @param array $topFolder
-	 * @param int $result
+	 * @param Folder $topFolder
+	 * @param array $result
 	 */
 	public function testPropertiesOfGetMediaFiles($topFolder, $result) {
 		$supportedMediaTypes = [


### PR DESCRIPTION
Fixes #25. It replaces #485 and #520 .
### Featuring
- Drag and drop component
- Folder uploading on Chrome
- File comparison dialogue
- [ + ] button 
- Improved empty page, now with error messages
### Todo
- [x] Defer quota check in web UI when overwriting shared file owncloud/core@ceaefc2
### Test plan

**Base**
- Uploading file(s) via drag and drop
- Uploading a folder via drag and drop
- Uploading file(s) via the [+] menu

**Additional tests**
- Uploading from an empty Gallery should work and the UI should adapt to the content of the album
- Uploading the same file twice should bring up the conflict dialogue
### Tech review
- The javascript used in `files` is loaded as-is. A special file has been created to replace FileList and Files methods called by those scripts
- `newfilemenu.js` has been imported and modified to make it work with Gallery. We don't need more than the upload entry
- `OC.Upload._isReceivedSharedFile` is replaced with a method which does the lookup in the cache instead of in the HTML
- Some methods were moved from Gallery to GalleryView as it made more sense to have them there
- GalleryImage has 2 new properties: size and sharedWithUser
- The landing page for empty albums has been modified to take into consideration the context in which that page is called and can print the error message, if communicated to the frontend

_Note: Ideally, we should switch to webdav once uploading is supported and re-usable components for the file dialogue move outside of `files`._

---

@karlitschek @jancborchardt @DeepDiver1975 @LukasReschke @PVince81 @MorrisJobke @jospoortvliet @setnes @demattin @arkascha @elpraga @sualko @bugsbane @mmattel @tahaalibra @viraj96 @imjalpreet @mbtamuli @rahulgoyal030
