### PR TITLE
Sort button hidden if only one image in album

### DIFF
--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -232,8 +232,17 @@
 			var availableWidth = $(window).width() - Gallery.buttonsWidth;
 			this.breadcrumb.init(albumPath, availableWidth);
 
-			$('#sort-name-button').show();
-			$('#sort-date-button').show();
+            if (Gallery.albumMap[Gallery.currentAlbum].images.length <= 1)
+            {
+                $('#sort-name-button').hide();
+                $('#sort-date-button').hide();
+            }
+            else
+            {
+                $('#sort-name-button').show();
+                $('#sort-date-button').show();
+            }
+
 			var currentSort = Gallery.config.albumSorting;
 			this.sortControlsSetup(currentSort.type, currentSort.order);
 			Gallery.albumMap[Gallery.currentAlbum].images.sort(


### PR DESCRIPTION
Fixes: _#573_

Licence: AGPL
### Description

Sort buttons were shown irrespective of whether there was one or more images. If there is only one image, sort buttons need not be shown
### Features
- Sort buttons are now shown only when there are more than one
### Screenshots or screencasts

![one](https://cloud.githubusercontent.com/assets/10382077/13664635/7362a3b2-e6ce-11e5-87bb-e01288a418bd.png)
![many](https://cloud.githubusercontent.com/assets/10382077/13664641/76e89a46-e6ce-11e5-88bd-a9b9564de5ef.png)
### Tested on
- [*] Ubuntu 15.10/Chrome
- [*] Ubuntu 15.10/Firefox
### Reviewers

@oparoz This commit solves issue #573
