### PR TITLE
Issue #213: No possibility to send an email in share dialog

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -82,11 +82,7 @@ class PageController extends Controller {
 		$appName = $this->appName;
 
 		// Parameters sent to the template
-		$params = [
-			'appName' => $appName,
-			'uploadUrl' => $this->urlGenerator->linkTo('files', 'ajax/upload.php'),
-			'publicUploadEnabled' => $this->appConfig->getAppValue('core', 'shareapi_allow_public_upload', 'yes')
-		];
+		$params = $this->getIndexParameters($appName);
 
 		// Will render the page using the template found in templates/index.php
 		$response = new TemplateResponse($appName, 'index', $params);
@@ -174,6 +170,35 @@ class PageController extends Controller {
 	 */
 	public function slideshow() {
 		return new TemplateResponse($this->appName, 'slideshow', [], 'blank');
+	}
+
+	/**
+	 * Returns the parameters to be used in the index function
+	 *
+	 * @param $appName
+	 *
+	 * @return array<string,string>
+	 */
+	private function getIndexParameters($appName) {
+
+		// Parameters sent to the index function
+		$params = [
+			'appName' => $appName,
+			'uploadUrl' => $this->urlGenerator->linkTo(
+				'files', 'ajax/upload.php'
+			),
+			'publicUploadEnabled' => $this->appConfig->getAppValue(
+				'core', 'shareapi_allow_public_upload', 'yes'
+			),
+			'mailNotificationEnabled' => $this->appConfig->getAppValue(
+				'core', 'shareapi_allow_mail_notification', 'no'
+			),
+			'mailPublicNotificationEnabled' => $this->appConfig->getAppValue(
+				'core', 'shareapi_allow_public_notification', 'no'
+			)
+		];
+
+		return $params;
 	}
 
 	/**

--- a/js/vendor/owncloud/share.js
+++ b/js/vendor/owncloud/share.js
@@ -254,18 +254,18 @@
 						t('core', 'Allow editing') + '</label>';
 						html += '</div>';
 					}
-					 /*var mailPublicNotificationEnabled = $(
-					 'input:hidden[name=mailPublicNotificationEnabled]').val();
-					 if (mailPublicNotificationEnabled === 'yes') {
-					 html += '<form id="emailPrivateLink">';
-					 html +=
-					 '<input id="email" style="display:none; width:62%;" value="" placeholder="' +
-					 t('core', 'Email link to person') + '" type="text" />';
-					 html +=
-					 '<input id="emailButton" style="display:none;" type="submit" value="' +
-					 t('core', 'Send') + '" />';
-					 html += '</form>';
-					 }*/
+
+					var mailPublicNotificationEnabled = $('input:hidden[name=mailPublicNotificationEnabled]').val();
+					if (mailPublicNotificationEnabled === 'yes') {
+						html += '<form id="emailPrivateLink">';
+						html +=
+							'<input id="email" style="display:none; width:62%;" value="" placeholder="' +
+							t('core', 'Email link to person') + '" type="text" />';
+						html +=
+							'<input id="emailButton" style="display:none;" type="submit" value="' +
+							t('core', 'Send') + '" />';
+						html += '</form>';
+					}
 				}
 
 				html += '<div id="expiration">';
@@ -443,32 +443,32 @@
 						.append(insert)
 						.appendTo(ul);
 				};
-				// FIXME Emailing links is not supported in Gallery
-				/*if (link && linksAllowed && $('#email').length != 0) {
-				 $('#email').autocomplete({
-				 minLength: 1,
-				 source: function (search, response) {
-				 $.get(OC.filePath('core', 'ajax', 'share.php'), {
-				 fetch: 'getShareWithEmail',
-				 search: search.term
-				 }, function (result) {
-				 if (result.status == 'success' && result.data.length > 0) {
-				 response(result.data);
-				 }
-				 });
-				 },
-				 select: function (event, item) {
-				 $('#email').val(item.item.email);
-				 return false;
-				 }
-				 })
-				 .data("ui-autocomplete")._renderItem = function (ul, item) {
-				 return $('<li>')
-				 .append('<a>' + escapeHTML(item.displayname) + "<br>" +
-				 escapeHTML(item.email) + '</a>')
-				 .appendTo(ul);
-				 };
-				 }*/
+
+				if (link && linksAllowed && $('#email').length != 0) {
+					$('#email').autocomplete({
+						minLength: 1,
+						source: function (search, response) {
+							$.get(OC.filePath('core', 'ajax', 'share.php'), {
+								fetch: 'getShareWithEmail',
+								search: search.term
+							}, function (result) {
+								if (result.status == 'success' && result.data.length > 0) {
+									response(result.data);
+								}
+							});
+						},
+						select: function (event, item) {
+							$('#email').val(item.item.email);
+							return false;
+						}
+					})
+						.data("ui-autocomplete")._renderItem = function (ul, item) {
+						return $('<li>')
+							.append('<a>' + escapeHTML(item.displayname) + "<br>" +
+							escapeHTML(item.email) + '</a>')
+							.appendTo(ul);
+					};
+				}
 
 			} else {
 				html += '<input id="shareWith" type="text" placeholder="' +
@@ -721,15 +721,15 @@
 			if (mailNotificationEnabled === 'yes' &&
 				shareType !== this.SHARE_TYPE_REMOTE) {
 				var checked = '';
-				if (mailSend === '1') {
+				if (mailSend === 1) {
 					checked = 'checked';
 				}
 				html +=
-					'<input type="checkbox" class="checkbox checkbox--right" ' +
-					'name="mailNotification" class="mailNotification" ' +
+					'<input id="mail-' + escapeHTML(shareWith) + '" type="checkbox" class="mailNotification checkbox checkbox--right" ' +
+					'name="mailNotification" ' +
 					checked + ' />';
 				html +=
-					'<label>' + t('core', 'notify by email') + '</label>';
+					'<label for="mail-' + escapeHTML(shareWith) + '">' + t('core', 'notify by email') + '</label>';
 			}
 			if (oc_appconfig.core.resharingAllowed &&
 				(possiblePermissions & OC.PERMISSION_SHARE)) {
@@ -1171,73 +1171,69 @@ $(document).ready(function () {
 	});
 
 
-	// FIXME Emailing links is not supported in Gallery
-	/*$(document).on('submit', '#dropdown #emailPrivateLink', function (event) {
-	 event.preventDefault();
-	 var link = $('#linkText').val();
-	 var itemType = $('#dropdown').data('item-type');
-	 var itemSource = $('#dropdown').data('item-source');
-	 var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
-	 var email = $('#email').val();
-	 var expirationDate = '';
-	 if ($('#expirationCheckbox').is(':checked') === true) {
-	 expirationDate = $("#expirationDate").val();
-	 }
-	 if (email != '') {
-	 $('#email').prop('disabled', true);
-	 $('#email').val(t('core', 'Sending ...'));
-	 $('#emailButton').prop('disabled', true);
+	$(document).on('submit', '#dropdown #emailPrivateLink', function (event) {
+		event.preventDefault();
+		var link = $('#linkText').val();
+		var itemType = $('#dropdown').data('item-type');
+		var itemSource = $('#dropdown').data('item-source');
+		var fileName = $('.last').children()[0].innerText;
+		var email = $('#email').val();
+		var expirationDate = '';
+		if ($('#expirationCheckbox').is(':checked') === true) {
+			expirationDate = $("#expirationDate").val();
+		}
+		if (email != '') {
+			$('#email').prop('disabled', true);
+			$('#email').val(t('core', 'Sending ...'));
+			$('#emailButton').prop('disabled', true);
 
-	 $.post(OC.filePath('core', 'ajax', 'share.php'), {
-	 action: 'email',
-	 toaddress: email,
-	 link: link,
-	 itemType: itemType,
-	 itemSource: itemSource,
-	 file: file,
-	 expiration: expirationDate
-	 },
-	 function (result) {
-	 $('#email').prop('disabled', false);
-	 $('#emailButton').prop('disabled', false);
-	 if (result && result.status == 'success') {
-	 $('#email').css('font-weight', 'bold').val(t('core', 'Email sent'));
-	 setTimeout(function () {
-	 $('#email').css('font-weight', 'normal').val('');
-	 }, 2000);
-	 } else {
-	 OC.dialogs.alert(result.data.message, t('core', 'Error while sharing'));
-	 }
-	 });
-	 }
-	 });*/
+			$.post(OC.filePath('core', 'ajax', 'share.php'), {
+					action: 'email',
+					toaddress: email,
+					link: link,
+					file: fileName,
+					itemType: itemType,
+					itemSource: itemSource,
+					expiration: expirationDate
+				},
+				function (result) {
+					$('#email').prop('disabled', false);
+					$('#emailButton').prop('disabled', false);
+					if (result && result.status == 'success') {
+						$('#email').css('font-weight', 'bold').val(t('core', 'Email sent'));
+						setTimeout(function () {
+							$('#email').css('font-weight', 'normal').val('');
+						}, 2000);
+					} else {
+						OC.dialogs.alert(result.data.message, t('core', 'Error while sharing'));
+					}
+				});
+		}
+	});
 
-	// FIXME Emailing links is not supported in Gallery
-	/*$(document).on('click', '#dropdown input[name=mailNotification]', function () {
-	 var $li = $(this).closest('li');
-	 var itemType = $('#dropdown').data('item-type');
-	 var itemSource = $('#dropdown').data('item-source');
-	 var action = '';
-	 if (this.checked) {
-	 action = 'informRecipients';
-	 } else {
-	 action = 'informRecipientsDisabled';
-	 }
+	$(document).on('click', '#dropdown input[name=mailNotification]', function () {
+		var $li = $(this).closest('li');
+		var itemType = $('#dropdown').data('item-type');
+		var itemSource = $('a.share').data('item-source');
+		var action = '';
+		if (this.checked) {
+			action = 'informRecipients';
+		} else {
+			action = 'informRecipientsDisabled';
+		}
+		var shareType = $li.data('share-type');
+		var shareWith = $li.attr('data-share-with');
+		$.post(OC.filePath('core', 'ajax', 'share.php'), {
+			action: action,
+			recipient: shareWith,
+			shareType: shareType,
+			itemSource: itemSource,
+			itemType: itemType
+		}, function (result) {
+			if (result.status !== 'success') {
+				OC.dialogs.alert(t('core', result.data.message), t('core', 'Warning'));
+			}
+		});
 
-	 var shareType = $li.data('share-type');
-	 var shareWith = $li.attr('data-share-with');
-
-	 $.post(OC.filePath('core', 'ajax', 'share.php'), {
-	 action: action,
-	 recipient: shareWith,
-	 shareType: shareType,
-	 itemSource: itemSource,
-	 itemType: itemType
-	 }, function (result) {
-	 if (result.status !== 'success') {
-	 OC.dialogs.alert(t('core', result.data.message), t('core', 'Warning'));
-	 }
-	 });
-
-	 });*/
+	});
 });

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -131,6 +131,10 @@ style(
 <div id="gallery" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" class="hascontrols"></div>
 <div id="emptycontent" class="hidden"></div>
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
+<input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled"
+	   value="<?php p($_['mailNotificationEnabled']) ?>"/>
+<input type="hidden" name="mailPublicNotificationEnabled" id="mailPublicNotificationEnabled"
+	   value="<?php p($_['mailPublicNotificationEnabled']) ?>"/>
 <div class="hiddenuploadfield">
 	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"
 		   data-url="<?php print_unescaped($_['uploadUrl']); ?>"/>

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -72,12 +72,18 @@ class PageControllerTest extends \Test\TestCase {
 		$url = 'http://owncloud/ajax/upload.php';
 		$this->mockUrlToUploadEndpoint($url);
 		$publicUploadEnabled = 'yes';
+		$mailNotificationEnabled = 'no';
+		$mailPublicNotificationEnabled = 'yes';
 		$params = [
 			'appName' => $this->appName,
 			'uploadUrl' => $url,
-			'publicUploadEnabled' => $publicUploadEnabled
+			'publicUploadEnabled' => $publicUploadEnabled,
+			'mailNotificationEnabled' => $mailNotificationEnabled,
+			'mailPublicNotificationEnabled' => $mailPublicNotificationEnabled
 		];
-		$this->mockGetPublicUploadAppValue($publicUploadEnabled);
+		$this->mockGetTestAppValue(
+			$publicUploadEnabled, $mailNotificationEnabled, $mailPublicNotificationEnabled
+		);
 
 		$template = new TemplateResponse($this->appName, 'index', $params);
 
@@ -235,15 +241,19 @@ class PageControllerTest extends \Test\TestCase {
 						   ->willReturn($url);
 	}
 
-	private function mockGetPublicUploadAppValue($publicUploadEnabled) {
-		$this->appConfig->expects($this->once())
+	private function mockGetTestAppValue(
+		$publicUploadEnabled, $mailNotificationEnabled, $mailPublicNotificationEnabled
+	) {
+		$map = [
+			['core', 'shareapi_allow_public_upload', 'yes', $publicUploadEnabled],
+			['core', 'shareapi_allow_mail_notification', 'no', $mailNotificationEnabled],
+			['core', 'shareapi_allow_public_notification', 'no', $mailPublicNotificationEnabled]
+		];
+		$this->appConfig
 			->method('getAppValue')
-			->with(
-				'core',
-				'shareapi_allow_public_upload',
-				'yes'
-			)
-			->willReturn($publicUploadEnabled);
+			->will(
+				$this->returnValueMap($map)
+			);
 	}
 
 	/**


### PR DESCRIPTION
Fixes: \* #213 *

Licence: AGPL
### Description and Features

It is now possible to send an email from the share dialog in the Gallery
- [x] Emails containing the public link are sent to the given email address
- [x] Email notifications can be sent to internal users
### Screenshots or screencasts

![screenshot2](https://cloud.githubusercontent.com/assets/6432146/13709627/ea8492f4-e7da-11e5-9758-03804c35cbea.png)
![screenshot1](https://cloud.githubusercontent.com/assets/6432146/13709628/eab4bb78-e7da-11e5-9f57-000e41164a7a.png)
### Tested on
- [x] Ubuntu 14.04/Firefox
- [x] Ubuntu 14.04/Chrome
### Test Plan
- First step is to setup your email settings in the admin settings.
- Go to the Gallery App.
- Now, try to share a folder via link.
- Try to send the mail to a person by entering the email.
- Try to test in various browsers.
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@oparoz Please have a look at it.
