### PR TITLE
Issue #565: Add the checkbox in the share dialogue to allow uploading from the public side

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -84,7 +84,8 @@ class PageController extends Controller {
 		// Parameters sent to the template
 		$params = [
 			'appName' => $appName,
-			'uploadUrl' => $this->urlGenerator->linkTo('files', 'ajax/upload.php')
+			'uploadUrl' => $this->urlGenerator->linkTo('files', 'ajax/upload.php'),
+			'publicUploadEnabled' => $this->appConfig->getAppValue('core', 'shareapi_allow_public_upload', 'yes')
 		];
 
 		// Will render the page using the template found in templates/index.php

--- a/js/vendor/owncloud/share.js
+++ b/js/vendor/owncloud/share.js
@@ -173,20 +173,19 @@
 				// Used later on to determine if the
 				// respective checkbox should be checked or
 				// not.
-				// FIXME public uploading is not supported in Gallery
-				/*var publicUploadEnabled = $('#filestable').data('allow-public-upload');
-				 if (typeof publicUploadEnabled == 'undefined') {
-				 publicUploadEnabled = 'no';
-				 }
-				 var allowPublicUploadStatus = false;
+				var publicUploadEnabled = $('#gallery').data('allow-public-upload');
+				if (typeof publicUploadEnabled == 'undefined') {
+					publicUploadEnabled = 'no';
+				}
+				var allowPublicUploadStatus = false;
 
-				 $.each(data, function (key, value) {
-				 if (value.share_type === self.SHARE_TYPE_LINK) {
-				 allowPublicUploadStatus =
-				 (value.permissions & OC.PERMISSION_CREATE) ? true : false;
-				 return true;
-				 }
-				 });*/
+				$.each(data, function (key, value) {
+					if (value.share_type === self.SHARE_TYPE_LINK) {
+						allowPublicUploadStatus =
+							(value.permissions & OC.PERMISSION_CREATE) ? true : false;
+						return true;
+					}
+				});
 
 				var sharePlaceholder = t('core', 'Share with users or groups …');
 				if (oc_appconfig.core.remoteShareAllowed) {
@@ -244,20 +243,18 @@
 					html += '<span class="icon-loading-small hidden"></span>';
 					html += '</div>';
 
-					// FIXME public uploading is not supported in Gallery
-					/*if (itemType === 'folder' && (possiblePermissions & OC.PERMISSION_CREATE) &&
-					 publicUploadEnabled === 'yes') {
-					 html += '<div id="allowPublicUploadWrapper" style="display:none;">';
-					 html += '<span class="icon-loading-small hidden"></span>';
-					 html +=
-					 '<input type="checkbox" class="checkbox checkbox--right" value="1" name="allowPublicUpload" id="sharingDialogAllowPublicUpload"' +
-					 ((allowPublicUploadStatus) ? 'checked="checked"' : '') + ' />';
-					 html += '<label for="sharingDialogAllowPublicUpload">' +
-					 t('core', 'Allow editing') + '</label>';
-					 html += '</div>';
-					 }
-					 html += '</div>';
-					 var mailPublicNotificationEnabled = $(
+					if (itemType === 'folder' && (possiblePermissions & OC.PERMISSION_CREATE) &&
+						publicUploadEnabled === 'yes') {
+						html += '<div id="allowPublicUploadWrapper" style="display:none;">';
+						html += '<span class="icon-loading-small hidden"></span>';
+						html +=
+							'<input type="checkbox" class="checkbox checkbox--right" value="1" name="allowPublicUpload" id="sharingDialogAllowPublicUpload"' +
+							((allowPublicUploadStatus) ? 'checked="checked"' : '') + ' />';
+						html += '<label for="sharingDialogAllowPublicUpload">' +
+						t('core', 'Allow editing') + '</label>';
+						html += '</div>';
+					}
+					 /*var mailPublicNotificationEnabled = $(
 					 'input:hidden[name=mailPublicNotificationEnabled]').val();
 					 if (mailPublicNotificationEnabled === 'yes') {
 					 html += '<form id="emailPrivateLink">';
@@ -1028,38 +1025,38 @@ $(document).ready(function () {
 	});
 
 	// Handle the Allow Public Upload Checkbox
-	// FIXME public uploading is not supported in Gallery
-	/*$(document).on('click', '#sharingDialogAllowPublicUpload', function () {
+	$(document).on('click', '#sharingDialogAllowPublicUpload', function () {
 
-	 // Gather data
-	 var $dropDown = $('#dropdown');
-	 var allowPublicUpload = $(this).is(':checked');
-	 var $button = $(this);
-	 var $loading = $dropDown.find('#allowPublicUploadWrapper .icon-loading-small');
+		// Gather data
+		var $dropDown = $('#dropdown');
+		var shareId = $('#linkCheckbox').data('id');
+		var allowPublicUpload = $(this).is(':checked');
+		var $button = $(this);
+		var $loading = $dropDown.find('#allowPublicUploadWrapper .icon-loading-small');
 
-	 if (!$loading.hasClass('hidden')) {
-	 // already in progress
-	 return false;
-	 }
+		if (!$loading.hasClass('hidden')) {
+			// already in progress
+			return false;
+		}
 
-	 // Update the share information
-	 $button.addClass('hidden');
-	 $button.prop('disabled', true);
-	 $loading.removeClass('hidden');
-	 //(path, shareType, shareWith, publicUpload, password, permissions)
-	 $.ajax({
-	 url: OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares/' + shareId +
-	 '?format=json',
-	 type: 'PUT',
-	 data: {
-	 publicUpload: allowPublicUpload
-	 }
-	 }).done(function () {
-	 $loading.addClass('hidden');
-	 $button.removeClass('hidden');
-	 $button.prop('disabled', false);
-	 });
-	 });*/
+		// Update the share information
+		$button.addClass('hidden');
+		$button.prop('disabled', true);
+		$loading.removeClass('hidden');
+		//(path, shareType, shareWith, publicUpload, password, permissions)
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1', 2) + 'shares/' + shareId +
+			'?format=json',
+			type: 'PUT',
+			data: {
+				publicUpload: allowPublicUpload
+			}
+		}).done(function () {
+			$loading.addClass('hidden');
+			$button.removeClass('hidden');
+			$button.prop('disabled', false);
+		});
+	});
 
 	$(document).on('click', '#dropdown #showPassword', function () {
 		$('#linkPass').slideToggle(OC.menuSpeed);

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -128,7 +128,7 @@ style(
 		</div>
 	</span>
 </div>
-<div id="gallery" class="hascontrols"></div>
+<div id="gallery" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" class="hascontrols"></div>
 <div id="emptycontent" class="hidden"></div>
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>
 <div class="hiddenuploadfield">


### PR DESCRIPTION
Fixes: #565 

Licence: AGPL
### Description and Features
- [x] Now, it is possible to allow editing via a share link(from the public side) from the share dialog in the Gallery.
### Screenshots or screencasts

![screenshot2](https://cloud.githubusercontent.com/assets/6432146/13710061/3150f0c2-e7dd-11e5-8b57-d3acaff77e3d.png)
![screenshot1](https://cloud.githubusercontent.com/assets/6432146/13710060/31508a1a-e7dd-11e5-8dee-670b78485774.png)
### Tested on
- [x] Ubuntu 14.04/Firefox
- [x] Ubuntu 14.04/Chrome
### Test Plan

As a logged-in user:
- First enable public uploading in the admin settings.
- Share a folder via link.
- Tick the 'Allow editing' check box.
- As #574 is not yet merged, we will have to go to the files list to test the uploading function.
- Try to test in multiple browsers.
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@oparoz Please have a look at this.
