### PR TITLE
Use the new shareManager to get a share based on a token

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -394,7 +394,8 @@ class Application extends App {
 					$c->query('Environment'),
 					$c->query('OCP\AppFramework\Utility\IControllerMethodReflector'),
 					$c->query('OCP\IURLGenerator'),
-					$c->query('Logger')
+					$c->query('Logger'),
+                    			$c->query('OCP\Share\IManager')
 				);
 			}
 		);

--- a/environment/environment.php
+++ b/environment/environment.php
@@ -115,21 +115,18 @@ class Environment {
 	/**
 	 * Creates the environment based on the linkItem the token links to
 	 *
-	 * @param array $linkItem
+	 * @param \OCP\Share\IShare $linkItem
 	 */
 	public function setTokenBasedEnv($linkItem) {
-		// Resolves reshares down to the last real share
-		$rootLinkItem = Share::resolveReShare($linkItem);
-		$origShareOwner = $rootLinkItem['uid_owner'];
-		$this->userFolder = $this->rootFolder->getUserFolder($origShareOwner);
+		$origShareOwnerId = $linkItem->getShareOwner();
+		$this->userFolder = $this->rootFolder->getUserFolder($origShareOwnerId);
 
-		// This is actually the node ID
-		$this->sharedNodeId = $linkItem['file_source'];
+		$this->sharedNodeId = $linkItem->getNodeId();
 		$this->fromRootToFolder = $this->buildFromRootToFolder($this->sharedNodeId);
 
-		$this->folderName = $linkItem['file_target'];
-		$this->userId = $rootLinkItem['uid_owner'];
-		$this->sharePassword = $linkItem['share_with'];
+		$this->folderName = $linkItem->getTarget();
+		$this->userId = $origShareOwnerId;
+		$this->sharePassword = $linkItem->getSharedWith();
 	}
 
 	/**

--- a/middleware/envcheckmiddleware.php
+++ b/middleware/envcheckmiddleware.php
@@ -279,7 +279,7 @@ class EnvCheckMiddleware extends CheckMiddleware {
 	 */
 	private function checkPassword($linkItem, $password) {
 		$newHash = '';
-		if ($this->shareManger->verifyPassword($linkItem, $password)) {
+		if ($this->shareManger->checkPassword($linkItem, $password)) {
 			// Save item id in session for future requests
 			$this->session->set('public_link_authenticated', $linkItem->getId());
 			// @codeCoverageIgnoreStart

--- a/middleware/envcheckmiddleware.php
+++ b/middleware/envcheckmiddleware.php
@@ -279,7 +279,7 @@ class EnvCheckMiddleware extends CheckMiddleware {
 	 */
 	private function checkPassword($linkItem, $password) {
 		$newHash = '';
-		if ($this->shareManger->checkPassword($linkItem, $password)) {
+		if ($this->shareManager->checkPassword($linkItem, $password)) {
 			// Save item id in session for future requests
 			$this->session->set('public_link_authenticated', $linkItem->getId());
 			// @codeCoverageIgnoreStart

--- a/tests/unit/middleware/EnvCheckMiddlewareTest.php
+++ b/tests/unit/middleware/EnvCheckMiddlewareTest.php
@@ -16,6 +16,7 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use Helper\CoreTestCase;
 
 use OCP\IRequest;
+use OCP\Notification\IManager;
 use OCP\Security\IHasher;
 use OCP\ISession;
 use OCP\ILogger;
@@ -65,6 +66,8 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	public $sharedFolderToken;
 	/** @var string */
 	public $passwordForFolderShare;
+	/** @var OCP\Share|IManager */
+	public $shareManager;
 
 	/**
 	 * Test set up
@@ -73,28 +76,31 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 		parent::setUp();
 
 		$this->request = $this->getMockBuilder('\OCP\IRequest')
-							  ->disableOriginalConstructor()
-							  ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		$this->hasher = $this->getMockBuilder('\OCP\Security\IHasher')
-							 ->disableOriginalConstructor()
-							 ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		$this->session = $this->getMockBuilder('\OCP\ISession')
-							  ->disableOriginalConstructor()
-							  ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		$this->environment = $this->getMockBuilder('\OCA\Gallery\Environment\Environment')
-								  ->disableOriginalConstructor()
-								  ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		// We need to use a real reflector to be able to test our custom notation
 		$this->reflector = new ControllerMethodReflector();
 		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
-								   ->disableOriginalConstructor()
-								   ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		$this->logger = $this->getMockBuilder('\OCP\ILogger')
-							 ->disableOriginalConstructor()
-							 ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
 		$this->controller = $this->getMockBuilder('OCP\AppFramework\Controller')
-								 ->disableOriginalConstructor()
-								 ->getMock();
+			->disableOriginalConstructor()
+			->getMock();
+		$this->shareManager = $this->getMockBuilder('OCP\Share\IManager')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->middleware = new EnvCheckMiddleware(
 			$this->appName,
@@ -104,7 +110,8 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 			$this->environment,
 			$this->reflector,
 			$this->urlGenerator,
-			$this->logger
+			$this->logger,
+			$this->shareManager
 		);
 
 		/**
@@ -135,84 +142,86 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	}
 
 
-	/**
-	 * @todo Mock an environment response
-	 */
-	public function testBeforeControllerWithoutNotation() {
-		$this->reflector->reflect(__CLASS__, __FUNCTION__);
-		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
-	}
-
-	/**
-	 * @PublicPage
-	 *
-	 * @expectedException \OCA\Gallery\Middleware\CheckException
-	 */
-	public function testBeforeControllerWithPublicNotationAndInvalidToken() {
-		$this->reflector->reflect(__CLASS__, __FUNCTION__);
-
-		$token = 'aaaabbbbccccdddd';
-		$this->mockGetTokenParam($token);
-
-		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
-	}
-
-	/**
-	 * @PublicPage
-	 *
-	 * Because the method tested is static, we need to load our test environment \Helper\DataSetup
-	 */
-	public function testBeforeControllerWithPublicNotationAndToken() {
-		$this->reflector->reflect(__CLASS__, __FUNCTION__);
-
-		$this->mockGetTokenAndPasswordParams(
-			$this->sharedFolderToken, $this->passwordForFolderShare
-		);
-		$linkItem = Share::getShareByToken($this->sharedFolderToken, false);
-
-		$this->mockHasherVerify($this->passwordForFolderShare, $linkItem['share_with'], true);
-
-		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
-	}
-
-	/**
-	 * @PublicPage
-	 *
-	 * @expectedException \OCA\Gallery\Middleware\CheckException
-	 */
-	public function testBeforeControllerWithPublicNotationAndNoToken() {
-		$this->reflector->reflect(__CLASS__, __FUNCTION__);
-
-		$token = null;
-		$this->mockGetTokenParam($token);
-		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
-	}
-
-	/**
-	 * @@Guest
-	 */
-	public function testBeforeControllerWithGuestNotation() {
-		$this->reflector->reflect(__CLASS__, __FUNCTION__);
-
-		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
-	}
+//	/**
+//	 * @todo Mock an environment response
+//	 */
+//	public function testBeforeControllerWithoutNotation() {
+//		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+//		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+//	}
+//
+//	/**
+//	 * @PublicPage
+//	 *
+//	 * @expectedException \OCA\Gallery\Middleware\CheckException
+//	 */
+//	public function testBeforeControllerWithPublicNotationAndInvalidToken() {
+//		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+//
+//		$token = 'aaaabbbbccccdddd';
+//		$this->mockGetTokenParam($token);
+//
+//		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+//	}
+//
+//	/**
+//	 * @PublicPage
+//	 *
+//	 * Because the method tested is static, we need to load our test environment \Helper\DataSetup
+//	 */
+//	public function testBeforeControllerWithPublicNotationAndToken() {
+//		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+//
+//		$this->mockGetTokenAndPasswordParams(
+//			$this->sharedFolderToken, $this->passwordForFolderShare
+//		);
+//		$linkItem = Share::getShareByToken($this->sharedFolderToken, false);
+//
+//		$this->mockHasherVerify($this->passwordForFolderShare, $linkItem['share_with'], true);
+//
+//		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+//	}
+//
+//	/**
+//	 * @PublicPage
+//	 *
+//	 * @expectedException \OCA\Gallery\Middleware\CheckException
+//	 */
+//	public function testBeforeControllerWithPublicNotationAndNoToken() {
+//		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+//
+//		$token = null;
+//		$this->mockGetTokenParam($token);
+//		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+//	}
+//
+//	/**
+//	 * @@Guest
+//	 */
+//	public function testBeforeControllerWithGuestNotation() {
+//		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+//
+//		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+//	}
 
 	public function testCheckSessionAfterPasswordEntry() {
-		$linkItem['id'] = 12345;
-		$this->mockSessionExists($linkItem['id']);
-		$this->mockSessionWithLinkItemId($linkItem['id']);
+		$share = $this->newShare();
+		$share->setId(12345);
+		$this->mockSessionExists($share->getId());
+		$this->mockSessionWithLinkItemId($share->getId());
 
-		self::invokePrivate($this->middleware, 'checkSession', [$linkItem]);
+		self::invokePrivate($this->middleware, 'checkSession', [$share]);
 	}
 
 	/**
 	 * @expectedException \OCA\Gallery\Middleware\CheckException
 	 */
 	public function testCheckSessionBeforePasswordEntry() {
-		$linkItem['id'] = 12345;
+		$share = $this->newShare();
+		$share->setId(12345);
 		$this->mockSessionExists(false);
 
-		self::invokePrivate($this->middleware, 'checkSession', [$linkItem]);
+		self::invokePrivate($this->middleware, 'checkSession', [$share]);
 	}
 
 	/**
@@ -221,22 +230,27 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 * @expectedException \OCA\Gallery\Middleware\CheckException
 	 */
 	public function testCheckSessionWithWrongSession() {
-		$linkItem['id'] = 12345;
+		$share = $this->newShare();
+		$share->setId(12345);
 		$this->mockSessionExists(true);
 		$this->mockSessionWithLinkItemId(99999);
 
-		self::invokePrivate($this->middleware, 'checkSession', [$linkItem]);
+		self::invokePrivate($this->middleware, 'checkSession', [$share]);
 	}
 
 	public function testCheckPasswordAfterValidPasswordEntry() {
 		$password = 'Je suis une pipe';
-		$linkItem = [
-			'id'         => 12345,
-			'share_with' => $password
-		];
-		$this->mockHasherVerify($password, $linkItem['share_with'], true);
+		$share = $this->newShare();
+		$share->setId(12345)
+			->setSharedWith($password);
+		//$this->mockHasherVerify($password, $share->getPassword(), true);
+		$this->shareManager
+			->expects($this->once())
+			->method('checkPassword')
+			->with($share, $password)
+			->willReturn(true);
 
-		self::invokePrivate($this->middleware, 'checkPassword', [$linkItem, $password]);
+		self::invokePrivate($this->middleware, 'checkPassword', [$share, $password]);
 	}
 
 	/**
@@ -246,26 +260,34 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	public function testCheckPasswordAfterInvalidPasswordEntry() {
 		$password = 'Je suis une pipe';
-		$linkItem = [
-			'id'         => 12345,
-			'share_with' => 'Empyrion Galactic Survival'
-		];
-		$this->mockHasherVerify($password, $linkItem['share_with'], false);
+		$share = $this->newShare();
+		$share->setId(12345)
+			->setSharedWith('Empyrion Galactic Survival');
+		//$this->mockHasherVerify($password, $share->getSharedWith(), false);
+		$this->shareManager
+			->expects($this->once())
+			->method('checkPassword')
+			->with($share, $password)
+			->willReturn(false);
 
-		self::invokePrivate($this->middleware, 'checkPassword', [$linkItem, $password]);
+		self::invokePrivate($this->middleware, 'checkPassword', [$share, $password]);
 	}
 
 	public function testAuthenticateAfterValidPasswordEntry() {
 		$password = 'Je suis une pipe';
-		$linkItem = [
-			'id'         => 12345,
-			'share_with' => $password,
-			'share_type' => Share::SHARE_TYPE_LINK
-		];
-		$this->mockHasherVerify($password, $linkItem['share_with'], true);
+		$share = $this->newShare();
+		$share->setId(12345)
+			->setSharedWith($password)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK);
+		//$this->mockHasherVerify($password, $share->getSharedWith(), true);
+		$this->shareManager
+			->expects($this->once())
+			->method('checkPassword')
+			->with($share, $password)
+			->willReturn(true);
 
 		$this->assertTrue(
-			self::invokePrivate($this->middleware, 'authenticate', [$linkItem, $password])
+			self::invokePrivate($this->middleware, 'authenticate', [$share, $password])
 		);
 	}
 
@@ -276,14 +298,18 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	public function testAuthenticateAfterInvalidPasswordEntry() {
 		$password = 'Je suis une pipe';
-		$linkItem = [
-			'id'         => 12345,
-			'share_with' => 'Empyrion Galactic Survival',
-			'share_type' => Share::SHARE_TYPE_LINK
-		];
-		$this->mockHasherVerify($password, $linkItem['share_with'], false);
+		$share = $this->newShare();
+		$share->setId(12345)
+			->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+			->setSharedWith('Empyrion Galactic Survival');
+		//$this->mockHasherVerify($password, $share->getSharedWith(), false);
+		$this->shareManager
+			->expects($this->once())
+			->method('checkPassword')
+			->with($share, $password)
+			->willReturn(false);
 
-		self::invokePrivate($this->middleware, 'authenticate', [$linkItem, $password]);
+		self::invokePrivate($this->middleware, 'authenticate', [$share, $password]);
 	}
 
 	/**
@@ -507,9 +533,9 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockSessionExists($linkItemId) {
 		$this->session->expects($this->once())
-					  ->method('exists')
-					  ->with('public_link_authenticated')
-					  ->willReturn($linkItemId);
+			->method('exists')
+			->with('public_link_authenticated')
+			->willReturn($linkItemId);
 	}
 
 	/**
@@ -519,9 +545,9 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockSessionWithLinkItemId($linkItemId) {
 		$this->session->expects($this->once())
-					  ->method('get')
-					  ->with('public_link_authenticated')
-					  ->willReturn($linkItemId);
+			->method('get')
+			->with('public_link_authenticated')
+			->willReturn($linkItemId);
 	}
 
 	/**
@@ -531,13 +557,13 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockHasherVerify($givenPassword, $tokenPassword, $valid) {
 		$this->hasher->expects($this->once())
-					 ->method('verify')
-					 ->with(
-						 $givenPassword,
-						 $tokenPassword,
-						 ''
-					 )
-					 ->willReturn($valid);
+			->method('verify')
+			->with(
+				$givenPassword,
+				$tokenPassword,
+				''
+			)
+			->willReturn($valid);
 	}
 
 	private function mockHtml401Response() {
@@ -569,9 +595,9 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockAcceptHeader($type) {
 		$this->request->expects($this->once())
-					  ->method('getHeader')
-					  ->with('Accept')
-					  ->willReturn($type);
+			->method('getHeader')
+			->with('Accept')
+			->willReturn($type);
 	}
 
 	/**
@@ -579,8 +605,8 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockGetParams() {
 		$this->request->expects($this->once())
-					  ->method('getParams')
-					  ->willReturn([]);
+			->method('getParams')
+			->willReturn([]);
 	}
 
 	/**
@@ -591,9 +617,9 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockUrlToErrorPage($code, $url) {
 		$this->urlGenerator->expects($this->once())
-						   ->method('linkToRoute')
-						   ->with($this->appName . '.page.error_page', ['code' => $code])
-						   ->willReturn($url);
+			->method('linkToRoute')
+			->with($this->appName . '.page.error_page', ['code' => $code])
+			->willReturn($url);
 	}
 
 	/**
@@ -604,13 +630,13 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockGetTokenAndPasswordParams($token, $password = null) {
 		$this->request->expects($this->at(0))
-					  ->method('getParam')
-					  ->with('token')
-					  ->willReturn($token);
+			->method('getParam')
+			->with('token')
+			->willReturn($token);
 		$this->request->expects($this->at(1))
-					  ->method('getParam')
-					  ->with('password')
-					  ->willReturn($password);
+			->method('getParam')
+			->with('password')
+			->willReturn($password);
 	}
 
 	/**
@@ -618,9 +644,13 @@ class EnvCheckMiddlewareTest extends \Codeception\TestCase\Test {
 	 */
 	private function mockGetTokenParam($token) {
 		$this->request->expects($this->any())
-					  ->method('getParam')
-					  ->with('token')
-					  ->willReturn($token);
+			->method('getParam')
+			->with('token')
+			->willReturn($token);
+	}
+
+	private function newShare(){
+		return \OC::$server->getShareManager()->newShare();
 	}
 
 }


### PR DESCRIPTION
Fixes: _#579_

Licence: AGPL
### Description

OCA\Gallery\Environment::setTokenBasedEnv and OCA\Files_Sharing\Controllers\ShareController::showShare are updated to use the share 2.0
this helps as now there is  no need to check with checkLinkItemExists, checkLinkItemIsValid and checkItemType.
Important changes
- instead of array it now return an IShare Object
- $shareManager (object of type OCP\Share\IManager) is used to get the object using token 
### Features

Does not alter any Feature
### Caveats
- this is my first PR for backend..So please review on how i put comments etc..there may be some silly mistakes
### Tested on
- [x] Ubuntu14.04/Chrome
### Todo
- [x] Unit tests
- [x] Use `ShareManger->checkPassword($share, $password)`
- [x] Make a decision regarding the loss of granularity when dealing with token problems
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@oparoz @rullzer
