### PR TITLE
Close the share dialogue when performing another action, fixes #545

### DIFF
--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -157,6 +157,7 @@
 			event.stopPropagation();
 			// show loading animation
 			this.loader.show();
+			Gallery.Share.hideDropDown();
 		},
 
 		/**

--- a/js/galleryinfobox.js
+++ b/js/galleryinfobox.js
@@ -26,6 +26,7 @@
 		 * Shows an information box to the user
 		 */
 		showInfo: function () {
+			Gallery.Share.hideDropDown();
 			if (this.infoContentContainer.is(':visible')) {
 				this.infoContentContainer.slideUp();
 			} else {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -92,6 +92,8 @@
 		 * @returns {*}
 		 */
 		show: function (index) {
+			Gallery.Share.hideDropDown();
+			$('.album-info-container').slideUp();
 			this.hideErrorNotification();
 			this.active = true;
 			this.container.show();


### PR DESCRIPTION
Fixes: #545 

Licence: AGPL
### Description

Close the share dialogue when performing "another action". Used hideDropDown function for share dialog.
### Features

Another actions include:
- Clicking on album.
- Clicking on image.
- Clicking on info button.
### Tested on
- [X] Ubuntu 14.04/Chrome
### Reviewers

@oparoz 
