### PR TITLE
Send information about albums to the client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "codeception/codeception": "2.1.*",
     "codeception/phpbuiltinserver": "*",
     "codeception/c3": "2.*",
+    "flow/jsonpath": "^0.3.1",
     "phpdocumentor/phpdocumentor": "^2.8",
     "jakub-onderka/php-parallel-lint": "0.*",
     "jakub-onderka/php-console-highlighter": "0.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9e1416ad4e19d401bada6de68cb9fa1b",
+    "hash": "00793ba48ceddabede89d3362ad6033b",
+    "content-hash": "b35f229548eb370b67ae28ef02ef0f84",
     "packages": [
         {
             "name": "symfony/yaml",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
+                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -53,7 +54,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-14 14:14:09"
+            "time": "2016-02-23 07:41:20"
         }
     ],
     "packages-dev": [
@@ -177,22 +178,26 @@
         },
         {
             "name": "codeception/c3",
-            "version": "2.0.3",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/c3.git",
-                "reference": "30321efb2421c5d201d02e2cb8da1a1ca96e4a38"
+                "reference": "dc4d39b36d585c2eda58129407e78855ea67b1ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/c3/zipball/30321efb2421c5d201d02e2cb8da1a1ca96e4a38",
-                "reference": "30321efb2421c5d201d02e2cb8da1a1ca96e4a38",
+                "url": "https://api.github.com/repos/Codeception/c3/zipball/dc4d39b36d585c2eda58129407e78855ea67b1ca",
+                "reference": "dc4d39b36d585c2eda58129407e78855ea67b1ca",
                 "shasum": ""
             },
             "require": {
+                "composer-plugin-api": "^1.0",
                 "php": ">=5.4.0"
             },
-            "type": "library",
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Codeception\\c3\\Installer"
+            },
             "autoload": {
                 "psr-4": {
                     "Codeception\\c3\\": "."
@@ -204,8 +209,12 @@
             ],
             "authors": [
                 {
+                    "name": "Tiger Seo",
+                    "email": "tiger.seo@gmail.com"
+                },
+                {
                     "name": "Michael Bodnarchuk",
-                    "email": "davert.php@resend.cc",
+                    "email": "davert.php@codegyre.com",
                     "homepage": "http://codegyre.com"
                 }
             ],
@@ -215,45 +224,46 @@
                 "code coverage",
                 "codecoverage"
             ],
-            "time": "2014-11-18 22:06:45"
+            "time": "2016-02-09 23:31:08"
         },
         {
             "name": "codeception/codeception",
-            "version": "2.1.3",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "cd810cb78a869408602e17271f9b7368b09a7ca8"
+                "reference": "65971b0dee4972710365b6102154cd412a9bf7b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/cd810cb78a869408602e17271f9b7368b09a7ca8",
-                "reference": "cd810cb78a869408602e17271f9b7368b09a7ca8",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/65971b0dee4972710365b6102154cd412a9bf7b1",
+                "reference": "65971b0dee4972710365b6102154cd412a9bf7b1",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "facebook/webdriver": ">=1.0.1",
+                "facebook/webdriver": ">=1.0.1 <2.0",
                 "guzzlehttp/guzzle": ">=4.1.4 <7.0",
                 "guzzlehttp/psr7": "~1.0",
-                "php": ">=5.4.0",
-                "phpunit/phpunit": "~4.8.0",
-                "symfony/browser-kit": "~2.4",
-                "symfony/console": "~2.4",
-                "symfony/css-selector": "~2.4",
-                "symfony/dom-crawler": "~2.4,!=2.4.5",
-                "symfony/event-dispatcher": "~2.4",
-                "symfony/finder": "~2.4",
-                "symfony/yaml": "~2.4"
+                "php": ">=5.4.0 <8.0",
+                "phpunit/php-code-coverage": ">=2.1.3",
+                "phpunit/phpunit": ">4.8.20 <6.0",
+                "symfony/browser-kit": ">=2.5 <3.1",
+                "symfony/console": ">=2.5 <3.1",
+                "symfony/css-selector": ">=2.5 <3.1",
+                "symfony/dom-crawler": ">=2.5 <3.1",
+                "symfony/event-dispatcher": ">=2.5 <3.1",
+                "symfony/finder": ">=2.5 <3.1",
+                "symfony/yaml": ">=2.5 <3.1"
             },
             "require-dev": {
                 "codeception/specify": "~0.3",
-                "facebook/php-sdk-v4": "~4.0",
+                "facebook/php-sdk-v4": "~5.0",
                 "flow/jsonpath": "~0.2",
                 "monolog/monolog": "~1.8",
                 "pda/pheanstalk": "~2.0",
-                "videlalvaro/php-amqplib": "~2.4"
+                "php-amqplib/php-amqplib": "~2.4"
             },
             "suggest": {
                 "codeception/phpbuiltinserver": "Extension to start and stop PHP built-in web server for your tests",
@@ -295,24 +305,24 @@
                 "functional testing",
                 "unit testing"
             ],
-            "time": "2015-10-02 09:38:59"
+            "time": "2016-03-12 01:15:25"
         },
         {
             "name": "codeception/phpbuiltinserver",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tiger-seo/PhpBuiltinServer.git",
-                "reference": "730206313b7e85d9ed4838ba02a0aee24fce1239"
+                "reference": "53cd8fc4b1134e9e2c1a6d7478490db11160e323"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tiger-seo/PhpBuiltinServer/zipball/730206313b7e85d9ed4838ba02a0aee24fce1239",
-                "reference": "730206313b7e85d9ed4838ba02a0aee24fce1239",
+                "url": "https://api.github.com/repos/tiger-seo/PhpBuiltinServer/zipball/53cd8fc4b1134e9e2c1a6d7478490db11160e323",
+                "reference": "53cd8fc4b1134e9e2c1a6d7478490db11160e323",
                 "shasum": ""
             },
             "require": {
-                "codeception/codeception": ">=2.0.2",
+                "codeception/codeception": "~2.0",
                 "php": ">=5.4.0"
             },
             "type": "library",
@@ -335,7 +345,7 @@
             "keywords": [
                 "codeception"
             ],
-            "time": "2014-09-19 10:14:07"
+            "time": "2016-01-14 00:29:41"
         },
         {
             "name": "doctrine/annotations",
@@ -554,16 +564,16 @@
         },
         {
             "name": "facebook/webdriver",
-            "version": "1.0.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "fe1bbbc5dde804d08a8593f1d9d0d3b05f5c84f5"
+                "reference": "1c98108ba3eb435b681655764de11502a0653705"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/fe1bbbc5dde804d08a8593f1d9d0d3b05f5c84f5",
-                "reference": "fe1bbbc5dde804d08a8593f1d9d0d3b05f5c84f5",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/1c98108ba3eb435b681655764de11502a0653705",
+                "reference": "1c98108ba3eb435b681655764de11502a0653705",
                 "shasum": ""
             },
             "require": {
@@ -593,7 +603,45 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2015-08-12 20:21:31"
+            "time": "2015-12-31 15:58:49"
+        },
+        {
+            "name": "flow/jsonpath",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FlowCommunications/JSONPath.git",
+                "reference": "e064398010089f9efb46044f85ee63c458ae89e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FlowCommunications/JSONPath/zipball/e064398010089f9efb46044f85ee63c458ae89e1",
+                "reference": "e064398010089f9efb46044f85ee63c458ae89e1",
+                "shasum": ""
+            },
+            "require-dev": {
+                "peekmo/jsonpath": "dev-master",
+                "phpunit/phpunit": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Flow\\JSONPath": "src/",
+                    "Flow\\JSONPath\\Test": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Frank",
+                    "email": "stephen@flowsa.com"
+                }
+            ],
+            "description": "JSONPath implementation for parsing, searching and flattening arrays",
+            "time": "2015-10-12 07:39:47"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -655,16 +703,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.2.0",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e"
+                "reference": "2e89629ff057ebb49492ba08e6995d3a6a80021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
-                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/2e89629ff057ebb49492ba08e6995d3a6a80021b",
+                "reference": "2e89629ff057ebb49492ba08e6995d3a6a80021b",
                 "shasum": ""
             },
             "require": {
@@ -709,7 +757,7 @@
                 "stream",
                 "uri"
             ],
-            "time": "2015-08-15 19:32:36"
+            "time": "2016-02-18 21:54:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -1018,16 +1066,16 @@
         },
         {
             "name": "jakub-onderka/php-parallel-lint",
-            "version": "v0.9",
+            "version": "v0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
-                "reference": "1b693fb455201cacf595163c92bfb1adfa2158d8"
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/1b693fb455201cacf595163c92bfb1adfa2158d8",
-                "reference": "1b693fb455201cacf595163c92bfb1adfa2158d8",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/2ead2e4043ab125bee9554f356e0a86742c2d4fa",
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa",
                 "shasum": ""
             },
             "require": {
@@ -1051,7 +1099,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-2-Clause"
             ],
             "authors": [
                 {
@@ -1061,7 +1109,7 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2015-06-16 10:17:07"
+            "time": "2015-12-15 10:42:16"
         },
         {
             "name": "jms/metadata",
@@ -1222,20 +1270,20 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "1.5.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "a4bee9f4b344b66e0a0d96c7afae1e92edf385fe"
+                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/a4bee9f4b344b66e0a0d96c7afae1e92edf385fe",
-                "reference": "a4bee9f4b344b66e0a0d96c7afae1e92edf385fe",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/cc84765fb7317f6b07bd8ac78364747f95b86341",
+                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": ">=5.3.29"
             },
             "require-dev": {
                 "json-schema/json-schema-test-suite": "1.1.0",
@@ -1248,7 +1296,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -1284,7 +1332,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2015-09-08 22:28:04"
+            "time": "2016-01-25 15:43:01"
         },
         {
             "name": "kherge/version",
@@ -1330,16 +1378,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.17.1",
+            "version": "1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422"
+                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0524c87587ab85bc4c2d6f5b41253ccb930a5422",
-                "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
                 "shasum": ""
             },
             "require": {
@@ -1353,10 +1401,11 @@
                 "aws/aws-sdk-php": "^2.4.9",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
                 "php-console/php-console": "^3.1.3",
                 "phpunit/phpunit": "~4.5",
                 "phpunit/phpunit-mock-objects": "2.3.0",
-                "raven/raven": "~0.11",
+                "raven/raven": "^0.13",
                 "ruflin/elastica": ">=0.90 <3.0",
                 "swiftmailer/swiftmailer": "~5.3",
                 "videlalvaro/php-amqplib": "~2.4"
@@ -1367,6 +1416,7 @@
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                 "ext-mongo": "Allow sending log messages to a MongoDB server",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "raven/raven": "Allow sending log messages to a Sentry server",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
@@ -1376,7 +1426,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1402,7 +1452,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-08-31 09:17:37"
+            "time": "2016-03-13 16:08:35"
         },
         {
             "name": "nikic/php-parser",
@@ -1827,22 +1877,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "~2.0"
@@ -1850,7 +1902,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -1883,20 +1935,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2016-02-15 07:46:21"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
@@ -1945,7 +1997,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-09-14 06:51:16"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2127,16 +2179,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.10",
+            "version": "4.8.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "463163747474815c5ccd4ae12b5b355ec12158e8"
+                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/463163747474815c5ccd4ae12b5b355ec12158e8",
-                "reference": "463163747474815c5ccd4ae12b5b355ec12158e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e351261f9cd33daf205a131a1ba61c6d33bd483",
+                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483",
                 "shasum": ""
             },
             "require": {
@@ -2195,7 +2247,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-01 09:14:30"
+            "time": "2016-02-11 14:56:33"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2388,16 +2440,16 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "3b6fca09c7d56321057fa8867c8dbe1abf648627"
+                "reference": "3aacad8bf10c7d83e6fa2089d413529888c2bedf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/3b6fca09c7d56321057fa8867c8dbe1abf648627",
-                "reference": "3b6fca09c7d56321057fa8867c8dbe1abf648627",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/3aacad8bf10c7d83e6fa2089d413529888c2bedf",
+                "reference": "3aacad8bf10c7d83e6fa2089d413529888c2bedf",
                 "shasum": ""
             },
             "require": {
@@ -2428,7 +2480,7 @@
                 }
             ],
             "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2015-07-03 13:48:55"
+            "time": "2016-02-26 19:09:02"
         },
         {
             "name": "sebastian/comparator",
@@ -2496,28 +2548,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -2540,24 +2592,24 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "shasum": ""
             },
             "require": {
@@ -2594,7 +2646,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2016-02-26 18:40:46"
         },
         {
             "name": "sebastian/exporter",
@@ -2664,16 +2716,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
@@ -2711,20 +2763,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2014-10-06 09:23:50"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -2764,7 +2816,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",
@@ -2803,20 +2855,20 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "863ae85c6d3ef60ca49cb12bd051c4a0648c40c4"
+                "reference": "66834d3e3566bb5798db7294619388786ae99394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/863ae85c6d3ef60ca49cb12bd051c4a0648c40c4",
-                "reference": "863ae85c6d3ef60ca49cb12bd051c4a0648c40c4",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/66834d3e3566bb5798db7294619388786ae99394",
+                "reference": "66834d3e3566bb5798db7294619388786ae99394",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^5.3 || ^7.0"
             },
             "bin": [
                 "bin/jsonlint"
@@ -2845,30 +2897,29 @@
                 "parser",
                 "validator"
             ],
-            "time": "2015-01-04 21:18:15"
+            "time": "2015-11-21 02:21:41"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "277a2457776d4cc25706fbdd9d1e4ab2dac884e4"
+                "reference": "6b2085020b4e86fcb7ae44c3ab8ddb91774b33d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/277a2457776d4cc25706fbdd9d1e4ab2dac884e4",
-                "reference": "277a2457776d4cc25706fbdd9d1e4ab2dac884e4",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/6b2085020b4e86fcb7ae44c3ab8ddb91774b33d2",
+                "reference": "6b2085020b4e86fcb7ae44c3ab8ddb91774b33d2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/dom-crawler": "~2.0,>=2.0.5"
+                "symfony/dom-crawler": "~2.0,>=2.0.5|~3.0.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.0,>=2.0.5",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.0,>=2.0.5"
+                "symfony/css-selector": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/process": "~2.3.34|~2.7,>=2.7.6|~3.0.0"
             },
             "suggest": {
                 "symfony/process": ""
@@ -2876,13 +2927,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\BrowserKit\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2900,39 +2954,42 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-06 08:36:38"
+            "time": "2016-01-27 11:34:40"
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9698fdf0a750d6887d5e7729d5cf099765b20e61"
+                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9698fdf0a750d6887d5e7729d5cf099765b20e61",
-                "reference": "9698fdf0a750d6887d5e7729d5cf099765b20e61",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
+                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/filesystem": "~2.3"
+                "symfony/filesystem": "~2.3|~3.0.0"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Config\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2950,30 +3007,30 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-21 15:02:29"
+            "time": "2016-02-22 16:12:45"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161"
+                "reference": "56cc5caf051189720b8de974e4746090aaa10d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/06cb17c013a82f94a3d840682b49425cd00a2161",
-                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161",
+                "url": "https://api.github.com/repos/symfony/console/zipball/56cc5caf051189720b8de974e4746090aaa10d44",
+                "reference": "56cc5caf051189720b8de974e4746090aaa10d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2983,13 +3040,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3007,38 +3067,38 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-25 08:32:23"
+            "time": "2016-02-28 16:20:50"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "abe19cc0429a06be0c133056d1f9859854860970"
+                "reference": "8d83ff9777cdbd83e7f90d9c48f4729823791a5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/abe19cc0429a06be0c133056d1f9859854860970",
-                "reference": "abe19cc0429a06be0c133056d1f9859854860970",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/8d83ff9777cdbd83e7f90d9c48f4729823791a5e",
+                "reference": "8d83ff9777cdbd83e7f90d9c48f4729823791a5e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3060,28 +3120,28 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-22 13:49:29"
+            "time": "2016-01-27 05:14:19"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "2e185ca136399f902b948694987e62c80099c052"
+                "reference": "e1a4b4c83f5ee6f5902f1d53035e3718909a0c11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2e185ca136399f902b948694987e62c80099c052",
-                "reference": "2e185ca136399f902b948694987e62c80099c052",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/e1a4b4c83f5ee6f5902f1d53035e3718909a0c11",
+                "reference": "e1a4b4c83f5ee6f5902f1d53035e3718909a0c11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.3",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/css-selector": "~2.8|~3.0.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -3089,13 +3149,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DomCrawler\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3113,20 +3176,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-20 21:13:58"
+            "time": "2016-02-28 16:20:50"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9"
+                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
-                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/78c468665c9568c3faaa9c416a7134308f2d85c3",
+                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3",
                 "shasum": ""
             },
             "require": {
@@ -3134,11 +3197,10 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/stopwatch": "~2.3"
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -3147,13 +3209,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3171,38 +3236,38 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-22 13:49:29"
+            "time": "2016-01-27 05:14:19"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "a17f8a17c20e8614c15b8e116e2f4bcde102cfab"
+                "reference": "65cb36b6539b1d446527d60457248f30d045464d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a17f8a17c20e8614c15b8e116e2f4bcde102cfab",
-                "reference": "a17f8a17c20e8614c15b8e116e2f4bcde102cfab",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/65cb36b6539b1d446527d60457248f30d045464d",
+                "reference": "65cb36b6539b1d446527d60457248f30d045464d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3220,38 +3285,38 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-09 17:42:36"
+            "time": "2016-02-22 15:02:30"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8262ab605973afbb3ef74b945daabf086f58366f"
+                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8262ab605973afbb3ef74b945daabf086f58366f",
-                "reference": "8262ab605973afbb3ef74b945daabf086f58366f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
+                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3269,38 +3334,97 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-19 19:59:23"
+            "time": "2016-02-22 16:12:45"
         },
         {
-            "name": "symfony/process",
-            "version": "v2.7.5",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "b27c8e317922cd3cdd3600850273cf6b82b2e8e9"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b27c8e317922cd3cdd3600850273cf6b82b2e8e9",
-                "reference": "b27c8e317922cd3cdd3600850273cf6b82b2e8e9",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "7dedd5b60550f33dca16dd7e94ef8aca8b67bbfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7dedd5b60550f33dca16dd7e94ef8aca8b67bbfe",
+                "reference": "7dedd5b60550f33dca16dd7e94ef8aca8b67bbfe",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3318,38 +3442,38 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-19 19:59:23"
+            "time": "2016-02-02 13:33:15"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "08dd97b3f22ab9ee658cd16e6758f8c3c404336e"
+                "reference": "e3bc8e2a984f4382690a438c8bb650f3ffd71e73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/08dd97b3f22ab9ee658cd16e6758f8c3c404336e",
-                "reference": "08dd97b3f22ab9ee658cd16e6758f8c3c404336e",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e3bc8e2a984f4382690a438c8bb650f3ffd71e73",
+                "reference": "e3bc8e2a984f4382690a438c8bb650f3ffd71e73",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Stopwatch\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3367,34 +3491,34 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-22 13:49:29"
+            "time": "2016-01-03 15:33:41"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "485877661835e188cd78345c6d4eef1290d17571"
+                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/485877661835e188cd78345c6d4eef1290d17571",
-                "reference": "485877661835e188cd78345c6d4eef1290d17571",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
+                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/config": "<2.7"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.7",
-                "symfony/intl": "~2.4",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/yaml": "~2.2"
+                "symfony/config": "~2.8",
+                "symfony/intl": "~2.4|~3.0.0",
+                "symfony/yaml": "~2.2|~3.0.0"
             },
             "suggest": {
                 "psr/log": "To use logging capability in translator",
@@ -3404,13 +3528,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3428,37 +3555,36 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-06 08:36:38"
+            "time": "2016-02-02 09:49:18"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "b359dc71e253ce6eb69eefbd5088032241e7a66f"
+                "reference": "3a529b9a428812c5ccb5e462c936e36f5492d716"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/b359dc71e253ce6eb69eefbd5088032241e7a66f",
-                "reference": "b359dc71e253ce6eb69eefbd5088032241e7a66f",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/3a529b9a428812c5ccb5e462c936e36f5492d716",
+                "reference": "3a529b9a428812c5ccb5e462c936e36f5492d716",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/translation": "~2.4"
+                "symfony/translation": "~2.4|~3.0.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.0",
                 "egulias/email-validator": "~1.2,>=1.2.1",
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.4",
-                "symfony/http-foundation": "~2.1",
-                "symfony/intl": "~2.4",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/property-access": "~2.3",
-                "symfony/yaml": "~2.0,>=2.0.5"
+                "symfony/config": "~2.2|~3.0.0",
+                "symfony/expression-language": "~2.4|~3.0.0",
+                "symfony/http-foundation": "~2.1|~3.0.0",
+                "symfony/intl": "~2.4|~3.0.0",
+                "symfony/property-access": "~2.3|~3.0.0",
+                "symfony/yaml": "~2.0,>=2.0.5|~3.0.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
@@ -3474,13 +3600,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Validator\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3498,20 +3627,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-23 11:13:27"
+            "time": "2016-02-23 18:27:29"
         },
         {
             "name": "twig/twig",
-            "version": "v1.22.2",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "79249fc8c9ff62e41e217e0c630e2e00bcadda6a"
+                "reference": "3e5aa30ebfbafd5951fb1b01e338e1800ce7e0e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/79249fc8c9ff62e41e217e0c630e2e00bcadda6a",
-                "reference": "79249fc8c9ff62e41e217e0c630e2e00bcadda6a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3e5aa30ebfbafd5951fb1b01e338e1800ce7e0e8",
+                "reference": "3e5aa30ebfbafd5951fb1b01e338e1800ce7e0e8",
                 "shasum": ""
             },
             "require": {
@@ -3524,7 +3653,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.22-dev"
+                    "dev-master": "1.24-dev"
                 }
             },
             "autoload": {
@@ -3559,7 +3688,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-09-22 13:59:32"
+            "time": "2016-01-25 21:22:18"
         },
         {
             "name": "zendframework/zend-cache",

--- a/controller/files.php
+++ b/controller/files.php
@@ -48,7 +48,7 @@ trait Files {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * Returns a list of all media files available to the authenticated user
+	 * Returns a list of all media files and albums available to the authenticated user
 	 *
 	 *    * Authentication can be via a login/password or a token/(password)
 	 *    * For private galleries, it returns all media files, with the full path from the root
@@ -64,22 +64,24 @@ trait Files {
 	 *
 	 * @return array <string,array<string,string|int>>|Http\JSONResponse
 	 */
-	private function getFiles($location, $features, $etag, $mediatypes) {
+	private function getFilesAndAlbums($location, $features, $etag, $mediatypes) {
 		$files = [];
+		$albums = [];
+		$updated = true;
 		/** @var Folder $folderNode */
-		list($folderPathFromRoot, $folderNode, $locationHasChanged) =
+		list($folderPathFromRoot, $folderNode) =
 			$this->searchFolderService->getCurrentFolder(rawurldecode($location), $features);
-		$albumInfo =
-			$this->configService->getAlbumInfo($folderNode, $folderPathFromRoot, $features);
-
-		if ($albumInfo['etag'] !== $etag) {
-			$files = $this->searchMediaService->getMediaFiles(
+		$albumConfig = $this->configService->getConfig($folderNode, $features);
+		if ($folderNode->getEtag() !== $etag) {
+			list($files, $albums) = $this->searchMediaService->getMediaFiles(
 				$folderNode, $mediatypes, $features
 			);
-			$files = $this->fixPaths($files, $folderPathFromRoot);
+		} else {
+			$updated = false;
 		}
+		$files = $this->fixPaths($files, $folderPathFromRoot);
 
-		return $this->formatResults($files, $albumInfo, $locationHasChanged);
+		return $this->formatResults($files, $albums, $albumConfig, $folderPathFromRoot, $updated);
 	}
 
 	/**
@@ -90,8 +92,8 @@ trait Files {
 	 * becomes
 	 * /root/folder/file.ext
 	 *
-	 * @param $files
-	 * @param $folderPathFromRoot
+	 * @param array $files
+	 * @param string $folderPathFromRoot
 	 *
 	 * @return array
 	 */
@@ -109,17 +111,22 @@ trait Files {
 	 * Simply builds and returns an array containing the list of files, the album information and
 	 * whether the location has changed or not
 	 *
-	 * @param array <string,string|int> $files
-	 * @param array $albumInfo
-	 * @param bool $locationHasChanged
+	 * @param array $files
+	 * @param array $albums
+	 * @param array $albumConfig
+	 * @param string $folderPathFromRoot
+	 * @param bool $updated
 	 *
 	 * @return array
+	 * @internal param $array <string,string|int> $files
 	 */
-	private function formatResults($files, $albumInfo, $locationHasChanged) {
+	private function formatResults($files, $albums, $albumConfig, $folderPathFromRoot, $updated) {
 		return [
-			'files'              => $files,
-			'albuminfo'          => $albumInfo,
-			'locationhaschanged' => $locationHasChanged
+			'files'       => $files,
+			'albums'      => $albums,
+			'albumconfig' => $albumConfig,
+			'albumpath'   => $folderPathFromRoot,
+			'updated'     => $updated
 		];
 	}
 

--- a/controller/filesapicontroller.php
+++ b/controller/filesapicontroller.php
@@ -92,7 +92,7 @@ class FilesApiController extends ApiController {
 		$featuresArray = explode(';', $features);
 		$mediaTypesArray = explode(';', $mediatypes);
 		try {
-			return $this->getFiles($location, $featuresArray, $etag, $mediaTypesArray);
+			return $this->getFilesAndAlbums($location, $featuresArray, $etag, $mediaTypesArray);
 		} catch (\Exception $exception) {
 			return $this->jsonError($exception);
 		}

--- a/controller/filescontroller.php
+++ b/controller/filescontroller.php
@@ -95,7 +95,7 @@ class FilesController extends Controller {
 		$featuresArray = explode(';', $features);
 		$mediaTypesArray = explode(';', $mediatypes);
 		try {
-			return $this->getFiles($location, $featuresArray, $etag, $mediaTypesArray);
+			return $this->getFilesAndAlbums($location, $featuresArray, $etag, $mediaTypesArray);
 		} catch (\Exception $exception) {
 			return $this->jsonError($exception);
 		}

--- a/environment/environment.php
+++ b/environment/environment.php
@@ -309,7 +309,7 @@ class Environment {
 	 *
 	 * That root folder changes when folders are shared publicly
 	 *
-	 * @param File|Folder $node
+	 * @param File|Folder|N $node
 	 *
 	 * @return string
 	 */

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -5,7 +5,9 @@
 	var TEMPLATE =
 		'<a class="row-element" style="width: {{targetWidth}}px; height: {{targetHeight}}px;" ' +
 		'data-width="{{targetWidth}}" data-height="{{targetHeight}}"' +
-		'href="{{targetPath}}" data-dir="{{dir}}" data-path="{{path}}">' +
+		'href="{{targetPath}}" data-dir="{{dir}}" data-path="{{path}}"' +
+		'data-permissions="{{permissions}}" data-freespace="{{freeSpace}}"' +
+		'>' +
 		'	<div class="album-loader loading"></div>' +
 		'	<span class="album-label">' +
 		'		<span class="title">{{label}}</span>' +
@@ -21,14 +23,31 @@
 	 * @param {Array<Album|GalleryImage>} subAlbums
 	 * @param {Array<Album|GalleryImage>} images
 	 * @param {string} name
+	 * @param {number} fileId
+	 * @param {number} mTime
+	 * @param {string} etag
+	 * @param {number} size
+	 * @param {Boolean} sharedWithUser
+	 * @param {string} owner
+	 * @param {number} freeSpace
+	 * @param {number} permissions
 	 * @constructor
 	 */
-	var Album = function (path, subAlbums, images, name) {
+	var Album = function (path, subAlbums, images, name, fileId, mTime, etag, size, sharedWithUser,
+						  owner, freeSpace, permissions) {
 		this.path = path;
 		this.subAlbums = subAlbums;
 		this.images = images;
 		this.viewedItems = 0;
 		this.name = name;
+		this.fileId = fileId;
+		this.mTime = mTime;
+		this.etag = etag;
+		this.size = size;
+		this.sharedWithUser = sharedWithUser;
+		this.owner = owner;
+		this.freeSpace = freeSpace;
+		this.permissions = permissions;
 		this.domDef = null;
 		this.loader = null;
 		this.preloadOffset = 0;
@@ -96,6 +115,8 @@
 					targetWidth: targetHeight,
 					dir: this.path,
 					path: this.path,
+					permissions: this.permissions,
+					freeSpace: this.freeSpace,
 					label: this.name,
 					targetPath: '#' + encodeURIComponent(this.path)
 				});
@@ -308,10 +329,11 @@
 			var subAlbum = this.domDef.children('.album');
 
 			if (this.images.length >= 1) {
-				this._getFourImages(this.images, targetHeight, subAlbum).fail(function (validImages) {
-					album.images = validImages;
-					album._fillSubAlbum(targetHeight, subAlbum);
-				});
+				this._getFourImages(this.images, targetHeight, subAlbum).fail(
+					function (validImages) {
+						album.images = validImages;
+						album._fillSubAlbum(targetHeight, subAlbum);
+					});
 			} else {
 				var imageHolder = $('<div class="cropped">');
 				subAlbum.append(imageHolder);
@@ -328,7 +350,7 @@
 		 */
 		_showFolder: function (targetHeight, imageHolder) {
 			var image = new GalleryImage('Generic folder', 'Generic folder', -1, 'image/svg+xml',
-			null,null);
+				null, null);
 			var thumb = Thumbnails.getStandardIcon(-1);
 			image.thumbnail = thumb;
 			this.images.push(image);

--- a/js/galleryconfig.js
+++ b/js/galleryconfig.js
@@ -17,7 +17,6 @@
 		cachedFeaturesString: '',
 		mediaTypes: [],
 		cachedMediaTypesString: '',
-		albumPermissions: null,
 		albumInfo: null,
 		albumSorting: null,
 		albumDesign: null,
@@ -46,19 +45,15 @@
 		 * Stores the configuration about the current album
 		 *
 		 * @param {{
-		 * 	fileid: number,
-		 * 	permissions: number,
-		 * 	path: string,
-		 * 	etag: string,
 		 * 	design,
 		 * 	information,
 		 * 	sorting,
 		 * 	error: string
 		 * }} albumConfig
+		 * @param albumPath
 		 */
-		setAlbumConfig: function (albumConfig) {
-			this.albumPermissions = this._setAlbumPermissions(albumConfig);
-			this.albumInfo = this._setAlbumInfo(albumConfig);
+		setAlbumConfig: function (albumConfig, albumPath) {
+			this.albumInfo = this._setAlbumInfo(albumConfig, albumPath);
 			this.albumSorting = this._setAlbumSorting(albumConfig);
 			this.albumDesign = this._setAlbumDesign(albumConfig);
 			this.albumError = albumConfig.error;
@@ -145,42 +140,15 @@
 		},
 
 		/**
-		 * Saves the permissions for the current album
-		 *
-		 * @param {{
-		 * 	fileid: number,
-		 * 	permissions: number,
-		 * 	path: string,
-		 * 	etag: string,
-		 * 	design,
-		 * 	information,
-		 * 	sorting,
-		 * 	error: string
-		 * }} albumConfig
-		 *
-		 * @returns {{fileid: number, permissions: number}}
-		 * @private
-		 */
-		_setAlbumPermissions: function (albumConfig) {
-			return {
-				path: albumConfig.path,
-				permissions: albumConfig.permissions
-			};
-		},
-
-		/**
 		 * Saves the description and copyright information for the current album
 		 *
 		 * @param {{
-		 * 	fileid: number,
-		 * 	permissions: number,
-		 * 	path: string,
-		 * 	etag: string,
 		 * 	design,
 		 * 	information,
 		 * 	sorting,
 		 * 	error: string
 		 * }} albumConfig
+		 * @param albumPath
 		 *
 		 * @returns {null||{
 		 * 	description: string,
@@ -193,9 +161,7 @@
 		 * }}
 		 * @private
 		 */
-		_setAlbumInfo: function (albumConfig) {
-			var albumPath = albumConfig.path;
-
+		_setAlbumInfo: function (albumConfig, albumPath) {
 			/**@type {{
 			 * 	description: string,
 			 * 	description_link: string,
@@ -239,10 +205,6 @@
 		 * Saves the description and copyright information for the current album
 		 *
 		 * @param {{
-		 * 	fileid: number,
-		 * 	permissions: number,
-		 * 	path: string,
-		 * 	etag: string,
 		 * 	design,
 		 * 	information,
 		 * 	sorting,
@@ -280,10 +242,6 @@
 		 * Saves the sorting configuration for the current album
 		 *
 		 * @param {{
-		 * 	fileid: number,
-		 * 	permissions: number,
-		 * 	path: string,
-		 * 	etag: string,
 		 * 	design,
 		 * 	information,
 		 * 	sorting,

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -23,9 +23,11 @@
 	 * @param {string} etag
 	 * @param {number} size
 	 * @param {boolean} sharedWithUser
+	 * @param {string} owner
 	 * @constructor
 	 */
-	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag, size, sharedWithUser) {
+	var GalleryImage = function (src, path, fileId, mimeType, mTime, etag, size, sharedWithUser,
+								 owner) {
 		this.src = src;
 		this.path = path;
 		this.fileId = fileId;
@@ -34,6 +36,7 @@
 		this.etag = etag;
 		this.size = size;
 		this.sharedWithUser = sharedWithUser;
+		this.owner = owner;
 		this.thumbnail = null;
 		this.domDef = null;
 		this.spinner = null;

--- a/service/configservice.php
+++ b/service/configservice.php
@@ -23,28 +23,19 @@ use OCA\Gallery\Preview\Preview;
 /**
  * Finds configurations files and returns a configuration array
  *
- * Checks the current and parent folders for configuration files and the privacy flag
+ * Checks the current and parent folders for configuration files and to see if we're allowed to
+ * look for media file
  * Supports explicit inheritance
  *
  * @package OCA\Gallery\Service
  */
 class ConfigService extends FilesService {
 
-	/**
-	 * @var string
-	 */
+	/** @var string */
 	private $configName = 'gallery.cnf';
-	/**
-	 * @var string
-	 */
-	private $privacyChecker = '.nomedia';
-	/**
-	 * @var array <string,bool>
-	 */
+	/** @var array <string,bool> */
 	private $completionStatus = ['design' => false, 'information' => false, 'sorting' => false];
-	/**
-	 * @var ConfigParser
-	 */
+	/** @var ConfigParser */
 	private $configParser;
 	/** @var Preview */
 	private $previewManager;
@@ -150,38 +141,28 @@ class ConfigService extends FilesService {
 	}
 
 	/**
-	 * Returns information about the currently selected folder
+	 * Returns the configuration of the currently selected folder
 	 *
-	 *    * privacy setting
-	 *    * special configuration
-	 *    * permissions
-	 *    * ID
+	 *    * information (description, copyright)
+	 *    * sorting (date, name, inheritance)
+	 *    * design (colour)
+	 *    * if the album should be ignored
 	 *
 	 * @param Folder $folderNode the current folder
-	 * @param string $folderPathFromRoot path from the current folder to the virtual root
 	 * @param array $features the list of features retrieved fro the configuration file
 	 *
 	 * @return array|null
 	 * @throws ForbiddenServiceException
 	 */
-	public function getAlbumInfo($folderNode, $folderPathFromRoot, $features) {
+	public function getConfig($folderNode, $features) {
 		$this->features = $features;
-		list ($albumConfig, $privateAlbum) =
-			$this->getAlbumConfig($folderNode, $this->privacyChecker, $this->configName);
-		if ($privateAlbum) {
+		list ($albumConfig, $ignored) =
+			$this->collectConfig($folderNode, $this->ignoreAlbum, $this->configName);
+		if ($ignored) {
 			throw new ForbiddenServiceException(
 				'The owner has placed a restriction or the storage location is unavailable'
 			);
 		}
-		$albumInfo = [
-			'path'           => $folderPathFromRoot,
-			'fileid'         => $folderNode->getId(),
-			'permissions'    => $folderNode->getPermissions(),
-			'etag'           => $folderNode->getEtag(),
-			'sharedWithUser' => $folderNode->isShared()
-		];
-		// There is always an albumInfo, but the albumConfig may be empty
-		$albumConfig = array_merge($albumInfo, $albumConfig);
 
 		return $albumConfig;
 	}
@@ -255,33 +236,34 @@ class ConfigService extends FilesService {
 	 * reached the root folder
 	 *
 	 * @param Folder $folder the current folder
-	 * @param string $privacyChecker name of the file which blacklists folders
+	 * @param string $ignoreAlbum name of the file which blacklists folders
 	 * @param string $configName name of the configuration file
 	 * @param int $level the starting level is 0 and we add 1 each time we visit a parent folder
-	 * @param array $config the configuration collected so far
+	 * @param array $collectedConfig the configuration collected so far
 	 *
-	 * @return array<null|array,bool>
+	 * @return array <null|array,bool>
 	 */
-	private function getAlbumConfig(
-		$folder, $privacyChecker, $configName, $level = 0, $config = []
+	private function collectConfig(
+		$folder, $ignoreAlbum, $configName, $level = 0, $collectedConfig = []
 	) {
-		if ($folder->nodeExists($privacyChecker)) {
+		if ($folder->nodeExists($ignoreAlbum)) {
 			// Cancel as soon as we find out that the folder is private or external
 			return [null, true];
 		}
 		$isRootFolder = $this->isRootFolder($folder, $level);
 		if ($folder->nodeExists($configName)) {
-			$config = $this->buildFolderConfig($folder, $configName, $config, $level);
+			$collectedConfig =
+				$this->buildFolderConfig($folder, $configName, $collectedConfig, $level);
 		}
 		if (!$isRootFolder) {
 			return $this->getParentConfig(
-				$folder, $privacyChecker, $configName, $level, $config
+				$folder, $ignoreAlbum, $configName, $level, $collectedConfig
 			);
 		}
-		$config = $this->validatesInfoConfig($config);
+		$collectedConfig = $this->validatesInfoConfig($collectedConfig);
 
 		// We have reached the root folder
-		return [$config, false];
+		return [$collectedConfig, false];
 	}
 
 	/**
@@ -290,22 +272,22 @@ class ConfigService extends FilesService {
 	 *
 	 * @param Folder $folder the current folder
 	 * @param string $configName name of the configuration file
-	 * @param array $config the configuration collected so far
+	 * @param array $collectedConfig the configuration collected so far
 	 * @param int $level the starting level is 0 and we add 1 each time we visit a parent folder
 	 *
 	 * @return array
 	 */
-	private function buildFolderConfig($folder, $configName, $config, $level) {
+	private function buildFolderConfig($folder, $configName, $collectedConfig, $level) {
 		try {
-			list($config, $completionStatus) = $this->configParser->getFolderConfig(
-				$folder, $configName, $config, $this->completionStatus, $level
+			list($collectedConfig, $completionStatus) = $this->configParser->getFolderConfig(
+				$folder, $configName, $collectedConfig, $this->completionStatus, $level
 			);
 			$this->completionStatus = $completionStatus;
 		} catch (ConfigException $exception) {
-			$config = $this->buildErrorMessage($exception, $folder);
+			$collectedConfig = $this->buildErrorMessage($exception, $folder);
 		}
 
-		return $config;
+		return $collectedConfig;
 	}
 
 	/**
@@ -367,16 +349,17 @@ class ConfigService extends FilesService {
 	 * @param string $privacyChecker name of the file which blacklists folders
 	 * @param string $configName name of the configuration file
 	 * @param int $level the starting level is 0 and we add 1 each time we visit a parent folder
-	 * @param array $config the configuration collected so far
+	 * @param array $collectedConfig the configuration collected so far
 	 *
 	 * @return array<null|array,bool>
 	 */
-	private function getParentConfig($folder, $privacyChecker, $configName, $level, $config) {
+	private function getParentConfig($folder, $privacyChecker, $configName, $level, $collectedConfig
+	) {
 		$parentFolder = $folder->getParent();
 		$level++;
 
-		return $this->getAlbumConfig(
-			$parentFolder, $privacyChecker, $configName, $level, $config
+		return $this->collectConfig(
+			$parentFolder, $privacyChecker, $configName, $level, $collectedConfig
 		);
 	}
 

--- a/service/searchfolderservice.php
+++ b/service/searchfolderservice.php
@@ -74,9 +74,8 @@ class SearchFolderService extends FilesService {
 			return $this->findFolder($folder, $depth);
 		}
 		$path = $this->environment->getPathFromVirtualRoot($node);
-		$locationHasChanged = $this->hasLocationChanged($depth);
 
-		return $this->sendFolder($path, $node, $locationHasChanged);
+		return $this->sendFolder($path, $node);
 	}
 
 	/**
@@ -97,31 +96,16 @@ class SearchFolderService extends FilesService {
 	}
 
 	/**
-	 * @param $depth
-	 *
-	 * @return bool
-	 */
-	private function hasLocationChanged($depth) {
-		$locationHasChanged = false;
-		if ($depth > 0) {
-			$locationHasChanged = true;
-		}
-
-		return $locationHasChanged;
-	}
-
-	/**
 	 * Makes sure that the folder is not empty, does meet our requirements in terms of location and
 	 * returns details about it
 	 *
 	 * @param string $path
 	 * @param Folder $node
-	 * @param bool $locationHasChanged
 	 *
 	 * @return array <string,Folder,bool>
 	 * @throws ForbiddenServiceException|NotFoundServiceException
 	 */
-	private function sendFolder($path, $node, $locationHasChanged) {
+	private function sendFolder($path, $node) {
 		if (is_null($node)) {
 			// Something very wrong has just happened
 			throw new NotFoundServiceException('Oh Nooooes!');
@@ -131,7 +115,7 @@ class SearchFolderService extends FilesService {
 			);
 		}
 
-		return [$path, $node, $locationHasChanged];
+		return [$path, $node];
 	}
 
 }

--- a/tests/_data/bom-gallery.cnf
+++ b/tests/_data/bom-gallery.cnf
@@ -7,7 +7,8 @@ design:
   background: "#ff9f00"
   inherit: yes
 information:
-  description: | # This is the official **Gallery** sample folder
+  description: |
+    # This is the official **Gallery** sample folder
     Contribute to this project [on Github](https://github.com/owncloud/gallery)
   copyright: Copyright 2014-2015 [Acme](http://www.ubersecrettester.ninja)
   inherit: yes

--- a/tests/_data/tester-gallery.cnf
+++ b/tests/_data/tester-gallery.cnf
@@ -7,7 +7,8 @@ design:
   background: "#ff9f00"
   inherit: yes
 information:
-  description: | # This is the official **Gallery** sample folder
+  description: |
+    # This is the official **Gallery** sample folder
     Contribute to this project [on Github](https://github.com/owncloud/gallery)
   copyright: Copyright 2014-2015 [Acme](http://www.ubersecrettester.ninja)
   inherit: yes

--- a/tests/api/GetFilesCest.php
+++ b/tests/api/GetFilesCest.php
@@ -59,20 +59,44 @@ class GetFilesCest {
 		$I->seeResponseCodeIs(200);
 		$I->seeResponseIsJson();
 
-		$I->seeResponseJsonMatchesXpath('//files/path');
+		$I->seeResponseJsonMatchesJsonPath('$.files[*]..path]');
+		$I->seeResponseJsonMatchesJsonPath('$.albums[*]..path]');
 		$I->dontSeeResponseContainsJson(['path' => 'folder2/testimagelarge.svg']);
 		// Folder 4 contains the .nomedia file
 		$I->dontSeeResponseContainsJson(['path' => 'folder4']);
-
-		$I->seeResponseJsonMatchesXpath('//albuminfo/path', '');
-
-		$I->seeResponseContainsJson(['locationhaschanged' => false]);
+		$I->seeResponseContainsJson(
+			[
+				'design'      => [
+					'background' => '#ff9f00',
+					'inherit'    => 'yes',
+					'level'      => 0,
+				],
+				'information' =>
+					[
+						// You have to use double-quotes here in order to be able to insert the line return
+						'description' => "# This is the official **Gallery** sample folder\xA" .
+										 "Contribute to this project [on Github](https://github.com/owncloud/gallery)\xA",
+						'copyright'   => 'Copyright 2014-2015 [Acme](http://www.ubersecrettester.ninja)',
+						'inherit'     => 'yes',
+						'level'       => 0,
+					],
+				'sorting'     =>
+					[
+						'type'    => 'date',
+						'order'   => 'des',
+						'inherit' => 'yes',
+						'level'   => 0,
+					],
+			]
+		);
+		$I->seeResponseContainsJson(['albumpath' => '']);
+		$I->seeResponseContainsJson(['updated' => true]);
 	}
 
 	/**
 	 * @depends getStandardList
 	 *
-	 * @param ApiTester $I
+	 * @param \Step\Api\User $I
 	 */
 	public function getListWithNativeSvgEnabled(\Step\Api\User $I) {
 		$mediaTypes = $this->params['mediatypes'];
@@ -102,13 +126,17 @@ class GetFilesCest {
 		$I->seeResponseCodeIs(200);
 		$I->seeResponseIsJson();
 		$I->seeResponseContainsJson(['path' => 'testimage-corrupt.jpg']);
-		$I->seeResponseContainsJson(['locationhaschanged' => true]);
+		$I->seeResponseContainsJson(['albumpath' => '']);
+		$I->seeResponseContainsJson(['updated' => true]);
 	}
 
 	public function getListOfParentFolderWhenFolderHasTypo(\Step\Api\User $I) {
 		$params = $this->params;
-		// The correct path is /folder1/shared1/shared1.1, containing testimage.png
-		$params['location'] = '/folder1/shared1/shared1.2';
+		// This doesn't match any path in the filesystem, the correct path is
+		// /folder1/shared1/shared1.1, containing testimage.png
+		$params['location'] = 'folder1/shared1/shared1.2';
+		// This is the path which will be used instead
+		$parentPath = 'folder1/shared1';
 
 		$I->am('an app');
 		$I->wantTo(
@@ -120,10 +148,44 @@ class GetFilesCest {
 		$I->seeResponseCodeIs(200);
 		$I->seeResponseIsJson();
 		// /folder1/shared1 only contains 2 files. Warning, alphabetical order
-		$I->seeResponseJsonMatchesXpath('//files[path[1]="folder1/shared1/testimage.eps"]');
-		// This is weird and might come from a bug in Codeception
-		$I->seeResponseJsonMatchesXpath('//files[path[1][1]="folder1/shared1/testimage.gif"]');
-		$I->seeResponseContainsJson(['locationhaschanged' => true]);
+		$I->seeResponseContainsJson(
+			[
+				'path'           => $parentPath . '/testimage.eps',
+				'sharedwithuser' => false,
+				'owner'          => [
+					'uid'         => 'tester',
+					'displayname' => 'Gallery Tester (tester)'
+				],
+				'permissions'    => 27,
+				'mimetype'       => 'application/postscript'
+			]
+		);
+		$I->seeResponseContainsJson(
+			[
+				'path'           => $parentPath . '/testimage.gif',
+				'sharedwithuser' => false,
+				'owner'          => [
+					'uid'         => 'tester',
+					'displayname' => 'Gallery Tester (tester)'
+				],
+				'permissions'    => 27,
+				'mimetype'       => 'image/gif'
+			]
+		);
+		$I->seeResponseJsonMatchesJsonPath('$.albums[*]..path]');
+		$I->seeResponseContainsJson(
+			[
+				'path'           => $parentPath,
+				'sharedwithuser' => false,
+				'owner'          => [
+					'uid'         => 'tester',
+					'displayname' => 'Gallery Tester (tester)'
+				],
+				'permissions'    => 31
+			]
+		);
+		$I->seeResponseContainsJson(['albumpath' => $parentPath]);
+		$I->seeResponseContainsJson(['updated' => true]);
 	}
 
 	public function getListOfForbiddenPath(\Step\Api\User $I) {

--- a/tests/unit/GalleryUnitTest.php
+++ b/tests/unit/GalleryUnitTest.php
@@ -93,12 +93,21 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 	 * @param string $etag
 	 * @param int $size
 	 * @param bool $isShared
+	 * @param null|object $owner
+	 * @param int $permissions
 	 *
 	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
 	protected function mockFile(
-		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
-		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024, $isShared = false
+		$fileId,
+		$storageId = 'home::user',
+		$isReadable = true,
+		$path = '',
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4",
+		$size = 1024,
+		$isShared = false,
+		$owner = null,
+		$permissions = 31
 	) {
 		$storage = $this->mockGetStorage($storageId);
 		$file = $this->getMockBuilder('OCP\Files\File')
@@ -110,6 +119,10 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 			 ->willReturn('file');
 		$file->method('getStorage')
 			 ->willReturn($storage);
+		$file->method('getOwner')
+			 ->willReturn($owner);
+		$file->method('getPermissions')
+			 ->willReturn($permissions);
 		$file->method('isReadable')
 			 ->willReturn($isReadable);
 		$file->method('getPath')
@@ -125,10 +138,19 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 	}
 
 	protected function mockJpgFile(
-		$fileId, $storageId = 'home::user', $isReadable = true, $path = '',
-		$etag = "8603c11cd6c5d739f2c156c38b8db8c4", $size = 1024, $isShared = false
+		$fileId,
+		$storageId = 'home::user',
+		$isReadable = true,
+		$path = '',
+		$etag = "8603c11cd6c5d739f2c156c38b8db8c4",
+		$size = 1024,
+		$isShared = false,
+		$owner = null,
+		$permissions = 31
 	) {
-		$file = $this->mockFile($fileId, $storageId, $isReadable, $path, $etag, $size, $isShared);
+		$file = $this->mockFile(
+			$fileId, $storageId, $isReadable, $path, $etag, $size, $isShared, $owner, $permissions
+		);
 		$this->mockJpgFileMethods($file);
 
 		return $file;
@@ -215,6 +237,25 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 		return $file;
 	}
 
+	/**
+	 * @param string $storageId
+	 * @param int $nodeId
+	 * @param array $files
+	 * @param bool $isReadable
+	 * @param bool $mounted
+	 * @param null $mount
+	 * @param string $query
+	 * @param bool $queryResult
+	 * @param bool $sharedWithUser
+	 * @param string $etag
+	 * @param int $size
+	 * @param string $path
+	 * @param null|object $owner
+	 * @param int $permissions
+	 * @param int $freeSpace
+	 *
+	 * @return mixed|object|\PHPUnit_Framework_MockObject_MockObject
+	 */
 	protected function mockFolder(
 		$storageId,
 		$nodeId,
@@ -223,7 +264,14 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 		$mounted = false,
 		$mount = null,
 		$query = '',
-		$queryResult = false
+		$queryResult = false,
+		$sharedWithUser = false,
+		$etag = "etag303",
+		$size = 4096,
+		$path = "not/important",
+		$owner = null,
+		$permissions = 31,
+		$freeSpace = 999999999
 	) {
 		$storage = $this->mockGetStorage($storageId);
 		$folder = $this->getMockBuilder('OCP\Files\Folder')
@@ -233,12 +281,26 @@ abstract class GalleryUnitTest extends \Test\TestCase {
 			   ->willReturn('dir');
 		$folder->method('getId')
 			   ->willReturn($nodeId);
+		$folder->method('getEtag')
+			   ->willReturn($etag);
+		$folder->method('getSize')
+			 ->willReturn($size);
+		$folder->method('getPath')
+			   ->willReturn($path);
+		$folder->method('getFreeSpace')
+			   ->willReturn($freeSpace);
 		$folder->method('getDirectoryListing')
 			   ->willReturn($files);
 		$folder->method('getStorage')
 			   ->willReturn($storage);
+		$folder->method('getOwner')
+			   ->willReturn($owner);
+		$folder->method('getPermissions')
+			   ->willReturn($permissions);
 		$folder->method('isReadable')
 			   ->willReturn($isReadable);
+		$folder->method('isShared')
+			   ->willReturn($sharedWithUser);
 		$folder->method('isMounted')
 			   ->willReturn($mounted);
 		$folder->method('getMountPoint')

--- a/tests/unit/service/SearchFolderServiceTest.php
+++ b/tests/unit/service/SearchFolderServiceTest.php
@@ -59,9 +59,8 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 	public function testSendFolderWithNullFolder() {
 		$path = '';
 		$node = null;
-		$locationHasChanged = false;
 
-		self::invokePrivate($this->service, 'sendFolder', [$path, $node, $locationHasChanged]);
+		self::invokePrivate($this->service, 'sendFolder', [$path, $node]);
 	}
 
 	/**
@@ -72,9 +71,8 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 		$nodeId = 94875;
 		$isReadable = false;
 		$node = $this->mockFolder('home::user', $nodeId, [], $isReadable);
-		$locationHasChanged = false;
 
-		self::invokePrivate($this->service, 'sendFolder', [$path, $node, $locationHasChanged]);
+		self::invokePrivate($this->service, 'sendFolder', [$path, $node]);
 	}
 
 	public function testSendFolder() {
@@ -82,9 +80,8 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 		$nodeId = 94875;
 		$files = [];
 		$node = $this->mockFolder('home::user', $nodeId, $files);
-		$locationHasChanged = false;
 
-		$folder = [$path, $node, $locationHasChanged];
+		$folder = [$path, $node];
 
 		$response = self::invokePrivate($this->service, 'sendFolder', $folder);
 
@@ -113,9 +110,7 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 		$files = [];
 		$shared = $this->mockFolder('shared::12345', $nodeId, $files);
 		$this->mockGetVirtualRootFolderOfSharedFolder($storageId, $shared);
-
-		$locationHasChanged = false;
-		$folder = [$path, $shared, $locationHasChanged];
+		$folder = [$path, $shared];
 		try {
 			$response = self::invokePrivate($this->service, 'sendFolder', $folder);
 			$this->assertSame($folder, $response);
@@ -270,25 +265,6 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 		$this->assertSame($expectedResult, $response);
 	}
 
-	public function providesLocationChangeData() {
-		return [
-			[0, false],
-			[1, true],
-		];
-	}
-
-	/**
-	 * @dataProvider providesLocationChangeData
-	 *
-	 * @param int $depth
-	 * @param bool $expectedResult
-	 */
-	public function testHasLocationChanged($depth, $expectedResult) {
-		$response = self::invokePrivate($this->service, 'hasLocationChanged', [$depth]);
-
-		$this->assertSame($expectedResult, $response);
-	}
-
 	public function providesValidateLocationData() {
 		return [
 			['folder1', 0, 'folder1'],
@@ -319,9 +295,8 @@ class SearchFolderServiceTest extends \Test\GalleryUnitTest {
 
 		$this->mockGetFileNodeFromVirtualRoot($location, $file);
 		$this->mockGetPathFromVirtualRoot($folder, $location);
-
-		$locationHasChanged = false;
-		$expectedResult = [$location, $folder, $locationHasChanged];
+		
+		$expectedResult = [$location, $folder];
 
 		$response = self::invokePrivate($this->service, 'findFolder', [$location]);
 

--- a/tests/unit/service/SearchMediaServiceTest.php
+++ b/tests/unit/service/SearchMediaServiceTest.php
@@ -45,19 +45,6 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$this->assertFalse($result);
 	}
 
-	public function testGetMediaFilesWithUnavailableFolder() {
-		$isReadable = false;
-		$files = [];
-		$topFolder = $this->mockFolder(
-			'home::user', 545454, $files, $isReadable
-		);
-		$supportedMediaTypes = [];
-		$features = [];
-		$response = $this->service->getMediaFiles($topFolder, $supportedMediaTypes, $features);
-
-		$this->assertSame([], $response);
-	}
-
 	public function providesTopFolderData() {
 		$isReadable = true;
 		$mounted = false;
@@ -66,46 +53,97 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$queryResult = false;
 
 		$folder1 = $this->mockFolder(
-			'home::user', 545454, [
-			$this->mockJpgFile(11111),
-			$this->mockJpgFile(22222),
-			$this->mockJpgFile(33333)
-		], $isReadable, $mounted, $mount, $query, $queryResult
+			'home::user', 545454,
+			[
+				$this->mockJpgFile(11111),
+				$this->mockJpgFile(22222),
+				$this->mockJpgFile(33333)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
 		);
 		$folder2 = $this->mockFolder(
-			'home::user', 767676, [
-			$this->mockJpgFile(44444),
-			$this->mockJpgFile(55555),
-			$this->mockJpgFile(66666)
-		], $isReadable, $mounted, $mount, $query, $queryResult
+			'home::user', 767676,
+			[
+				$this->mockJpgFile(44444),
+				$this->mockJpgFile(55555),
+				$this->mockJpgFile(66666)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$folder33 = $this->mockFolder(
+			'home::user', 545454,
+			[
+				$this->mockJpgFile(11111),
+				$this->mockJpgFile(22222),
+				$this->mockJpgFile(33333)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
 		);
 		$folder3 = $this->mockFolder(
-			'home::user', 101010, [$folder1], $isReadable, $mounted, $mount, $query, $queryResult
+			'home::user', 101010, [$folder33], $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$folder33b = $this->mockFolder(
+			'home::user', 545454,
+			[
+				$this->mockJpgFile(11111),
+				$this->mockJpgFile(22222),
+				$this->mockJpgFile(33333)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$folder3b = $this->mockFolder(
+			'home::user', 101010, [$folder33b], $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$folder44 = $this->mockFolder(
+			'home::user', 545454,
+			[
+				$this->mockJpgFile(11111),
+				$this->mockJpgFile(22222),
+				$this->mockJpgFile(33333)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$folder45 = $this->mockFolder(
+			'home::user', 767676,
+			[
+				$this->mockJpgFile(44444),
+				$this->mockJpgFile(55555),
+				$this->mockJpgFile(66666)
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
 		);
 		$folder4 = $this->mockFolder(
-			'home::user', 101010, [$folder1, $folder2], $isReadable, $mounted, $mount, $query,
+			'home::user', 101010,
+			[
+				$folder44,
+				$folder45
+			],
+			$isReadable, $mounted, $mount, $query,
 			$queryResult
 		);
 		$folder5 = $this->mockFolder(
-			'home::user', 987234, [
-			$this->mockJpgFile(998877),
-			$this->mockJpgFile(998876),
-			$this->mockNoMediaFile(998875)
-		], $isReadable, $mounted, $mount, '.nomedia', true
+			'home::user', 987234,
+			[
+				$this->mockJpgFile(998877),
+				$this->mockJpgFile(998876),
+				$this->mockNoMediaFile(998875)
+			],
+			$isReadable, $mounted, $mount, '.nomedia', true
 		);
 		$folder6 = $this->mockFolder(
-			'webdav::user@domain.com/dav', 545454, [
-			$this->mockJpgFile(11111)
-		], $isReadable, true, $mount, $query, $queryResult
+			'webdav::user@domain.com/dav', 545454, [$this->mockJpgFile(11111)], $isReadable, true,
+			$mount, $query, $queryResult
 		);
 		$folder7 = $this->mockFolder(
-			'home::user', 545454, [
-			$this->mockJpgFile(1),
-			$this->mockJpgFile(2),
-			$this->mockJpgFile(3),
-			$this->mockJpgFile(4),
-			$this->mockJpgFile(5),
-		], $isReadable, $mounted, $mount, $query, $queryResult
+			'home::user', 545454,
+			[
+				$this->mockJpgFile(1),
+				$this->mockJpgFile(2),
+				$this->mockJpgFile(3),
+				$this->mockJpgFile(4),
+				$this->mockJpgFile(5),
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult
 		);
 
 		// 2 folders and 3 files, everything is reachable
@@ -117,21 +155,58 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			$this->mockJpgFile(99999)
 
 		];
+		$folder1Path = 'holidays';
+		$folder2Path = 'athletics';
+		$topFolder1 = $this->mockFolder(
+			'home::user', 909090, $config1, $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$map1 = [
+			[$topFolder1, ''],
+			[$folder1, $folder1Path],
+			[$folder2, $folder2Path],
+		];
 		// 2 deepfolder and 3 files. Should return all the files
 		$config2 = [
 			$folder3,
-			$folder3,
+			$folder3b,
 			$this->mockJpgFile(77777),
 			$this->mockJpgFile(88888),
 			$this->mockJpgFile(99999)
 
 		];
-		// 1 deepfolder (with 2 sub-folders) and 3 files. Should return the files and the content of 1 folder
+		$folder3Path = 'ninja';
+		$folder3bPath = 'racing';
+		$folder33Path = 'ninja/mma';
+		$folder33bPath = 'racing/f1';
+		$topFolder2 = $this->mockFolder(
+			'home::user', 909090, $config2, $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$map2 = [
+			[$topFolder2, ''],
+			[$folder3, $folder3Path],
+			[$folder3b, $folder3bPath],
+			[$folder33, $folder33Path],
+			[$folder33b, $folder33bPath],
+		];
+		// 1 deepfolder (with 2 sub-folders) and 3 files. Should return the files and the content of
+		// 1 folder because we stop looking after we've found at least 1 picture in a sub-sub-folder
 		$config3 = [
 			$folder4,
 			$this->mockJpgFile(77777),
 			$this->mockJpgFile(88888),
 			$this->mockJpgFile(99999)
+		];
+		$folder4Path = 'trips';
+		$folder44Path = 'trips/NSA';
+		$folder45Path = 'trips/GCHQ';
+		$topFolder3 = $this->mockFolder(
+			'home::user', 909090, $config3, $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$map3 = [
+			[$topFolder3, ''],
+			[$folder4, $folder4Path],
+			[$folder44, $folder44Path],
+			[$folder45, $folder45Path],
 		];
 		// 1 blacklisted folder and 3 files
 		$config4 = [
@@ -141,7 +216,15 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			$this->mockJpgFile(99999)
 
 		];
-		// 1 standard folder, 1 external share and 3 files
+		$folder5Path = 'food';
+		$topFolder4 = $this->mockFolder(
+			'home::user', 909090, $config4, $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$map4 = [
+			[$topFolder4, ''],
+			[$folder5, $folder5Path],
+		];
+		// 1 standard folder, 1 external share (ignored) and 3 files
 		$config5 = [
 			$folder1,
 			$folder6,
@@ -150,6 +233,15 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			$this->mockJpgFile(99999)
 
 		];
+		$folder6Path = 'pets';
+		$topFolder5 = $this->mockFolder(
+			'home::user', 909090, $config5, $isReadable, $mounted, $mount, $query, $queryResult
+		);
+		$map5 = [
+			[$topFolder5, ''],
+			[$folder1, $folder1Path],
+			[$folder6, $folder6Path],
+		];
 		// 1 standard folder (3), 1 deep folder and 3 files
 		$config6 = [
 			$folder1,
@@ -157,34 +249,24 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 			$this->mockJpgFile(77777),
 			$this->mockJpgFile(88888),
 			$this->mockJpgFile(99999)
-
 		];
-		$topFolder1 = $this->mockFolder(
-			'home::user', 909090, $config1, $isReadable, $mounted, $mount, $query, $queryResult
-		);
-		$topFolder2 = $this->mockFolder(
-			'home::user', 909090, $config2, $isReadable, $mounted, $mount, $query, $queryResult
-		);
-		$topFolder3 = $this->mockFolder(
-			'home::user', 909090, $config3, $isReadable, $mounted, $mount, $query, $queryResult
-		);
-		$topFolder4 = $this->mockFolder(
-			'home::user', 909090, $config4, $isReadable, $mounted, $mount, $query, $queryResult
-		);
-		$topFolder5 = $this->mockFolder(
-			'home::user', 909090, $config5, $isReadable, $mounted, $mount, $query, $queryResult
-		);
+		$folder7Path = 'missions';
 		$topFolder6 = $this->mockFolder(
 			'home::user', 909090, $config6, $isReadable, $mounted, $mount, $query, $queryResult
 		);
+		$map6 = [
+			[$topFolder6, ''],
+			[$folder1, $folder1Path],
+			[$folder7, $folder7Path],
+		];
 
 		return [
-			[$topFolder1, 9],
-			[$topFolder2, 9],
-			[$topFolder3, 6],
-			[$topFolder4, 3],
-			[$topFolder5, 6],
-			[$topFolder6, 10]
+			[$topFolder1, $map1, 9, 3],
+			[$topFolder2, $map2, 9, 5],
+			[$topFolder3, $map3, 6, 3],
+			[$topFolder4, $map4, 3, 1],
+			[$topFolder5, $map5, 6, 2],
+			[$topFolder6, $map6, 10, 3]
 		];
 	}
 
@@ -192,19 +274,24 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 	 * @dataProvider providesTopFolderData
 	 *
 	 * @param Folder $topFolder
-	 * @param int $result
+	 * @param array $map
+	 * @param int $images
+	 * @param int $albums
+	 *
+	 * @internal param int $result
 	 */
-	public function testGetMediaFiles($topFolder, $result) {
+	public function testGetMediaFiles($topFolder, $map, $images, $albums) {
 		$supportedMediaTypes = [
 			'image/png',
 			'image/jpeg',
 			'image/gif'
 		];
 		$features = [];
-
+		$this->mockNodePath($map);
 		$response = $this->service->getMediaFiles($topFolder, $supportedMediaTypes, $features);
 
-		$this->assertSame($result, sizeof($response));
+		$this->assertSame($images, sizeof($response[0]));
+		$this->assertSame($albums, sizeof($response[1]));
 	}
 
 	public function providesFolderWithFilesData() {
@@ -214,64 +301,144 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$query = '.nomedia';
 		$queryResult = false;
 
-		$file1 = [
-			'fileid'         => 11111,
-			'storageId'      => 'home::user',
-			'isReadable'     => true,
-			'path'           => null,
+		// The order doesn't matter, but it's easier to compare
+		// if that matches the order in FileService::getNodeData
+		$topFolder1Data = [
+			'path'           => '',
+			'nodeid'         => 12121,
+			'mtime'          => null,
+			'etag'           => "5d739f2c156c38b8db8c48603c11cd6c",
+			'size'           => 88888,
+			'sharedwithuser' => false,
+			'owner'          => [],
+			'permissions'    => 31,
+			'freespace'      => 7777777,
+		];
+		$topFolder2Data = $topFolder1Data;
+		$file1Data = [
+			'path'           => 'rootfile.jpg',
+			'nodeid'         => 11111,
+			'mtime'          => null,
 			'etag'           => "8603c11cd6c5d739f2c156c38b8db8c4",
 			'size'           => 1024,
-			'sharedWithUser' => false,
-			'mimetype'       => 'image/jpeg'
+			'sharedwithuser' => false,
+			'owner'          => [],
+			'permissions'    => 31,
+			'mimetype'       => 'image/jpeg',
 		];
+		$file1 = $this->mockJpgFile(
+			$file1Data['nodeid'], 'home::user', $isReadable, $file1Data['path'],
+			$file1Data['etag'], $file1Data['size'], $file1Data['sharedwithuser'], null,
+			$file1Data['permissions']
+		);
 
-		$file2 = [
-			'fileid'         => 22222,
-			'storageId'      => 'webdav::user@domain.com/dav',
-			'isReadable'     => true,
-			'path'           => null,
+		$ownerUid = 909090;
+		$ownerName = 'San Akinamoura';
+		$owner = $this->mockOwner($ownerUid, $ownerName);
+		$file2Data = [
+			'path'           => 'holidays/everest.jpg',
+			'nodeid'         => 22222,
+			'mtime'          => null,
 			'etag'           => "739f2c156c38b88603c11cd6c5ddb8c4",
 			'size'           => 102410241024,
-			'sharedWithUser' => true,
-			'mimetype'       => 'image/jpeg'
+			'sharedwithuser' => true,
+			'owner'          => [
+				'uid'         => $ownerUid,
+				'displayname' => $ownerName
+			],
+			'permissions'    => 31,
+			'mimetype'       => 'image/jpeg',
 		];
-
-
-		$folder1 = $this->mockFolder(
-			'home::user', 545454, [
-			$this->mockJpgFile(
-				$file1['fileid'], $file1['storageId'], $file1['isReadable'], $file1['path'],
-				$file1['etag'], $file1['size'], $file1['sharedWithUser']
-			),
-			$this->mockJpgFile(
-				$file2['fileid'], $file2['storageId'], $file2['isReadable'], $file2['path'],
-				$file2['etag'], $file2['size'], $file2['sharedWithUser']
-			)
-		], $isReadable, $mounted, $mount, $query, $queryResult
+		$file2 = $this->mockJpgFile(
+			$file2Data['nodeid'], 'webdav::user@domain.com/dav', $isReadable, $file2Data['path'],
+			$file2Data['etag'], $file2Data['size'], $file2Data['sharedwithuser'], $owner,
+			$file2Data['permissions']
 		);
+
+		$album1Data = [
+			'path'           => 'holidays',
+			'nodeid'         => 454545,
+			'mtime'          => null,
+			'etag'           => "56c38b8db8c486035d739f2c1c11cd6c",
+			'size'           => 33333,
+			'sharedwithuser' => false,
+			'owner'          => [],
+			'permissions'    => 11,
+			'freespace'      => 576576576576,
+		];
+		$album1 = $this->mockFolder(
+			'home::user',
+			$album1Data['nodeid'], [
+				$file2
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult, $album1Data['sharedwithuser'],
+			$album1Data['etag'], $album1Data['size'], $album1Data['path'], null,
+			$album1Data['permissions'], $album1Data['freespace']
+		);
+
+		$topFolder1 = $this->mockFolder(
+			'home::user',
+			$topFolder1Data['nodeid'],
+			[
+				$file1,
+				$album1
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult, $topFolder1Data['sharedwithuser'],
+			$topFolder1Data['etag'], $topFolder1Data['size'], $topFolder1Data['path'], null,
+			$topFolder1Data['permissions'], $topFolder1Data['freespace']
+		);
+		$albumIgnored = $this->mockFolder(
+			'home::user',
+			$album1Data['nodeid'], [
+				$file2
+			],
+			$isReadable, $mounted, $mount, '.nomedia', true, $album1Data['sharedwithuser'],
+			$album1Data['etag'], $album1Data['size'], $album1Data['path'], null,
+			$album1Data['permissions'], $album1Data['freespace']
+		);
+		$topFolder2 = $this->mockFolder(
+			'home::user',
+			$topFolder1Data['nodeid'],
+			[
+				$file1,
+				$albumIgnored
+			],
+			$isReadable, $mounted, $mount, $query, $queryResult, $topFolder1Data['sharedwithuser'],
+			$topFolder1Data['etag'], $topFolder1Data['size'], $topFolder1Data['path'], null,
+			$topFolder1Data['permissions'], $topFolder1Data['freespace']
+		);
+
+		$map1 = [
+			[$topFolder1, $topFolder1Data['path']],
+			[$file1, $file1Data['path']],
+			[$file2, $file2Data['path']],
+			[$album1, $album1Data['path']],
+		];
+		$map2 = [
+			[$file1, $file1Data['path']],
+			[$topFolder2, $topFolder2Data['path']],
+		];
 
 		return [
 			[
-				$folder1, [
-				[
-					'path'           => $file1['path'],
-					'fileid'         => $file1['fileid'],
-					'mimetype'       => $file1['mimetype'],
-					'mtime'          => null,
-					'etag'           => $file1['etag'],
-					'size'           => $file1['size'],
-					'sharedWithUser' => $file1['sharedWithUser']
-				],
-				[
-					'path'           => $file2['path'],
-					'fileid'         => $file2['fileid'],
-					'mimetype'       => $file2['mimetype'],
-					'mtime'          => null,
-					'etag'           => $file2['etag'],
-					'size'           => $file2['size'],
-					'sharedWithUser' => $file2['sharedWithUser']
+				$topFolder1,
+				$map1, [
+					[
+						$file1Data,
+						$file2Data
+					],
+					[
+						$topFolder1Data['path'] => $topFolder1Data,
+						$album1Data['path']     => $album1Data,
+					]
 				]
-			]
+			],
+			[
+				$topFolder2,
+				$map2, [
+					[$file1Data],
+					[$topFolder2Data['path'] => $topFolder2Data,]
+				]
 			]
 		];
 	}
@@ -280,9 +447,10 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 	 * @dataProvider providesFolderWithFilesData
 	 *
 	 * @param Folder $topFolder
+	 * @param array $map
 	 * @param array $result
 	 */
-	public function testPropertiesOfGetMediaFiles($topFolder, $result) {
+	public function testPropertiesOfGetMediaFiles($topFolder, $map, $result) {
 		$supportedMediaTypes = [
 			'image/png',
 			'image/jpeg',
@@ -290,6 +458,7 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		];
 		$features = [];
 
+		$this->mockNodePath($map);
 		$response = $this->service->getMediaFiles($topFolder, $supportedMediaTypes, $features);
 
 		$this->assertSame($result, $response);
@@ -306,6 +475,39 @@ class SearchMediaServiceTest extends \Test\GalleryUnitTest {
 		$this->mockGetResourceFromId($this->environment, $fileId, $file);
 
 		$this->service->getResourceFromId($fileId);
+	}
+
+	/**
+	 * @param int $uid
+	 * @param string $displayName
+	 *
+	 * @return mixed|object|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function mockOwner($uid, $displayName) {
+		$owner = $this->getMockBuilder('OCP\IUser')
+					  ->disableOriginalConstructor()
+					  ->getMock();
+		$owner->method('getUID')
+			  ->willReturn($uid);
+		$owner->method('getDisplayName')
+			  ->willReturn($displayName);
+
+		return $owner;
+	}
+
+	/**
+	 * Mocks Environment->getPathFromVirtualRoot
+	 *
+	 * This is needed for files and albums to find the path to the root and is required to build
+	 * the hierarchy of folders
+	 *
+	 * @param $map
+	 */
+	private function mockNodePath($map) {
+		$this->environment->method('getPathFromVirtualRoot')
+						  ->will(
+							  $this->returnValueMap($map)
+						  );
 	}
 
 }

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -13,9 +13,7 @@
 namespace Composer\Autoload;
 
 /**
- * ClassLoader implements a PSR-0 class loader
- *
- * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
+ * ClassLoader implements a PSR-0, PSR-4 and classmap class loader.
  *
  *     $loader = new \Composer\Autoload\ClassLoader();
  *
@@ -39,6 +37,8 @@ namespace Composer\Autoload;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @see    http://www.php-fig.org/psr/psr-0/
+ * @see    http://www.php-fig.org/psr/psr-4/
  */
 class ClassLoader
 {
@@ -147,7 +147,7 @@ class ClassLoader
      * appending or prepending to the ones previously set for this namespace.
      *
      * @param string       $prefix  The prefix/namespace, with trailing '\\'
-     * @param array|string $paths   The PSR-0 base directories
+     * @param array|string $paths   The PSR-4 base directories
      * @param bool         $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -14,13 +14,6 @@ return array(
     'Symfony\\Component\\Yaml\\Exception\\RuntimeException' => $vendorDir . '/symfony/yaml/Exception/RuntimeException.php',
     'Symfony\\Component\\Yaml\\Inline' => $vendorDir . '/symfony/yaml/Inline.php',
     'Symfony\\Component\\Yaml\\Parser' => $vendorDir . '/symfony/yaml/Parser.php',
-    'Symfony\\Component\\Yaml\\Tests\\A' => $vendorDir . '/symfony/yaml/Tests/DumperTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\B' => $vendorDir . '/symfony/yaml/Tests/ParserTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\DumperTest' => $vendorDir . '/symfony/yaml/Tests/DumperTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\InlineTest' => $vendorDir . '/symfony/yaml/Tests/InlineTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\ParseExceptionTest' => $vendorDir . '/symfony/yaml/Tests/ParseExceptionTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\ParserTest' => $vendorDir . '/symfony/yaml/Tests/ParserTest.php',
-    'Symfony\\Component\\Yaml\\Tests\\YamlTest' => $vendorDir . '/symfony/yaml/Tests/YamlTest.php',
     'Symfony\\Component\\Yaml\\Unescaper' => $vendorDir . '/symfony/yaml/Unescaper.php',
     'Symfony\\Component\\Yaml\\Yaml' => $vendorDir . '/symfony/yaml/Yaml.php',
 );

--- a/vendor/composer/autoload_real.php
+++ b/vendor/composer/autoload_real.php
@@ -43,8 +43,3 @@ class ComposerAutoloaderInit3cfd72445e0ad28db5332442bcda1e66
         return $loader;
     }
 }
-
-function composerRequire3cfd72445e0ad28db5332442bcda1e66($file)
-{
-    require $file;
-}

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1,37 +1,37 @@
 [
     {
         "name": "symfony/yaml",
-        "version": "v2.7.5",
-        "version_normalized": "2.7.5.0",
+        "version": "v2.8.3",
+        "version_normalized": "2.8.3.0",
         "source": {
             "type": "git",
             "url": "https://github.com/symfony/yaml.git",
-            "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
+            "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
-            "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+            "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+            "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
             "shasum": ""
         },
         "require": {
             "php": ">=5.3.9"
         },
-        "require-dev": {
-            "symfony/phpunit-bridge": "~2.7"
-        },
-        "time": "2015-09-14 14:14:09",
+        "time": "2016-02-23 07:41:20",
         "type": "library",
         "extra": {
             "branch-alias": {
-                "dev-master": "2.7-dev"
+                "dev-master": "2.8-dev"
             }
         },
         "installation-source": "dist",
         "autoload": {
             "psr-4": {
                 "Symfony\\Component\\Yaml\\": ""
-            }
+            },
+            "exclude-from-classmap": [
+                "/Tests/"
+            ]
         },
         "notification-url": "https://packagist.org/downloads/",
         "license": [

--- a/vendor/symfony/yaml/CHANGELOG.md
+++ b/vendor/symfony/yaml/CHANGELOG.md
@@ -1,6 +1,26 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * Deprecated usage of a colon in an unquoted mapping value
+ * Deprecated usage of @, \`, | and > at the beginning of an unquoted string
+ * When surrounding strings with double-quotes, you must now escape `\` characters. Not
+   escaping those characters (when surrounded by double-quotes) is deprecated.
+
+   Before:
+
+   ```yml
+   class: "Foo\Var"
+   ```
+
+   After:
+
+   ```yml
+   class: "Foo\\Var"
+   ```
+
 2.1.0
 -----
 

--- a/vendor/symfony/yaml/Escaper.php
+++ b/vendor/symfony/yaml/Escaper.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Yaml;
  * YAML strings.
  *
  * @author Matthew Lewinski <matthew@lewinski.org>
+ *
+ * @internal
  */
 class Escaper
 {
@@ -31,13 +33,13 @@ class Escaper
                                      "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
                                      "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
                                      "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
-                                     "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9",);
+                                     "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9");
     private static $escaped = array('\\\\', '\\"', '\\\\', '\\"',
                                      '\\0',   '\\x01', '\\x02', '\\x03', '\\x04', '\\x05', '\\x06', '\\a',
                                      '\\b',   '\\t',   '\\n',   '\\v',   '\\f',   '\\r',   '\\x0e', '\\x0f',
                                      '\\x10', '\\x11', '\\x12', '\\x13', '\\x14', '\\x15', '\\x16', '\\x17',
                                      '\\x18', '\\x19', '\\x1a', '\\e',   '\\x1c', '\\x1d', '\\x1e', '\\x1f',
-                                     '\\N', '\\_', '\\L', '\\P',);
+                                     '\\N', '\\_', '\\L', '\\P');
 
     /**
      * Determines if a PHP value would require double quoting in YAML.

--- a/vendor/symfony/yaml/Exception/DumpException.php
+++ b/vendor/symfony/yaml/Exception/DumpException.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Yaml\Exception;
  * Exception class thrown when an error occurs during dumping.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 class DumpException extends RuntimeException
 {

--- a/vendor/symfony/yaml/Exception/ExceptionInterface.php
+++ b/vendor/symfony/yaml/Exception/ExceptionInterface.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Yaml\Exception;
  * Exception interface for all exceptions thrown by the component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 interface ExceptionInterface
 {

--- a/vendor/symfony/yaml/Exception/ParseException.php
+++ b/vendor/symfony/yaml/Exception/ParseException.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Yaml\Exception;
  * Exception class thrown when an error occurs during parsing.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 class ParseException extends RuntimeException
 {

--- a/vendor/symfony/yaml/Exception/RuntimeException.php
+++ b/vendor/symfony/yaml/Exception/RuntimeException.php
@@ -15,8 +15,6 @@ namespace Symfony\Component\Yaml\Exception;
  * Exception class thrown when an error occurs during parsing.
  *
  * @author Romain Neutron <imprec@gmail.com>
- *
- * @api
  */
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {

--- a/vendor/symfony/yaml/Inline.php
+++ b/vendor/symfony/yaml/Inline.php
@@ -52,7 +52,7 @@ class Inline
             return '';
         }
 
-        if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
+        if (2 /* MB_OVERLOAD_STRING */ & (int) ini_get('mbstring.func_overload')) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('ASCII');
         }
@@ -105,7 +105,7 @@ class Inline
                 return 'null';
             case is_object($value):
                 if ($objectSupport) {
-                    return '!!php/object:'.serialize($value);
+                    return '!php/object:'.serialize($value);
                 }
 
                 if ($exceptionOnInvalidType) {
@@ -204,6 +204,8 @@ class Inline
      * @return string A YAML string
      *
      * @throws ParseException When malformed inline YAML string is parsed
+     *
+     * @internal
      */
     public static function parseScalar($scalar, $delimiters = null, $stringDelimiters = array('"', "'"), &$i = 0, $evaluate = true, $references = array())
     {
@@ -224,14 +226,22 @@ class Inline
                 $i += strlen($output);
 
                 // remove comments
-                if (false !== $strpos = strpos($output, ' #')) {
-                    $output = rtrim(substr($output, 0, $strpos));
+                if (preg_match('/[ \t]+#/', $output, $match, PREG_OFFSET_CAPTURE)) {
+                    $output = substr($output, 0, $match[0][1]);
                 }
             } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {
                 $output = $match[1];
                 $i += strlen($output);
             } else {
                 throw new ParseException(sprintf('Malformed inline YAML string (%s).', $scalar));
+            }
+
+            // a non-quoted string cannot start with @ or ` (reserved) nor with a scalar indicator (| or >)
+            if ($output && ('@' === $output[0] || '`' === $output[0] || '|' === $output[0] || '>' === $output[0])) {
+                @trigger_error(sprintf('Not quoting the scalar "%s" starting with "%s" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $output, $output[0]), E_USER_DEPRECATED);
+
+                // to be thrown in 3.0
+                // throw new ParseException(sprintf('The reserved indicator "%s" cannot start a plain scalar; you need to quote the scalar.', $output[0]));
             }
 
             if ($evaluate) {
@@ -469,6 +479,16 @@ class Inline
                         return (string) substr($scalar, 5);
                     case 0 === strpos($scalar, '! '):
                         return (int) self::parseScalar(substr($scalar, 2));
+                    case 0 === strpos($scalar, '!php/object:'):
+                        if (self::$objectSupport) {
+                            return unserialize(substr($scalar, 12));
+                        }
+
+                        if (self::$exceptionOnInvalidType) {
+                            throw new ParseException('Object support when parsing a YAML file has been disabled.');
+                        }
+
+                        return;
                     case 0 === strpos($scalar, '!!php/object:'):
                         if (self::$objectSupport) {
                             return unserialize(substr($scalar, 13));
@@ -502,7 +522,12 @@ class Inline
                     case preg_match('/^(-|\+)?[0-9,]+(\.[0-9]+)?$/', $scalar):
                         return (float) str_replace(',', '', $scalar);
                     case preg_match(self::getTimestampRegex(), $scalar):
-                        return strtotime($scalar);
+                        $timeZone = date_default_timezone_get();
+                        date_default_timezone_set('UTC');
+                        $time = strtotime($scalar);
+                        date_default_timezone_set($timeZone);
+
+                        return $time;
                 }
             default:
                 return (string) $scalar;

--- a/vendor/symfony/yaml/LICENSE
+++ b/vendor/symfony/yaml/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/symfony/yaml/Parser.php
+++ b/vendor/symfony/yaml/Parser.php
@@ -20,7 +20,9 @@ use Symfony\Component\Yaml\Exception\ParseException;
  */
 class Parser
 {
-    const FOLDED_SCALAR_PATTERN = '(?P<separator>\||>)(?P<modifiers>\+|\-|\d+|\+\d+|\-\d+|\d+\+|\d+\-)?(?P<comments> +#.*)?';
+    const BLOCK_SCALAR_HEADER_PATTERN = '(?P<separator>\||>)(?P<modifiers>\+|\-|\d+|\+\d+|\-\d+|\d+\+|\d+\-)?(?P<comments> +#.*)?';
+    // BC - wrongly named
+    const FOLDED_SCALAR_PATTERN = self::BLOCK_SCALAR_HEADER_PATTERN;
 
     private $offset = 0;
     private $lines = array();
@@ -60,7 +62,7 @@ class Parser
         $value = $this->cleanup($value);
         $this->lines = explode("\n", $value);
 
-        if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
+        if (2 /* MB_OVERLOAD_STRING */ & (int) ini_get('mbstring.func_overload')) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('UTF-8');
         }
@@ -112,7 +114,7 @@ class Parser
 
                         $data[] = $parser->parse($block, $exceptionOnInvalidType, $objectSupport, $objectForMap);
                     } else {
-                        $data[] = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport, $objectForMap);
+                        $data[] = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport, $objectForMap, $context);
                     }
                 }
                 if ($isRef) {
@@ -228,7 +230,7 @@ class Parser
                         }
                     }
                 } else {
-                    $value = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport, $objectForMap);
+                    $value = $this->parseValue($values['value'], $exceptionOnInvalidType, $objectSupport, $objectForMap, $context);
                     // Spec: Keys MUST be unique; first one wins.
                     // But overwriting is allowed when a merge node is used in current block.
                     if ($allowOverwrite || !isset($data[$key])) {
@@ -301,6 +303,16 @@ class Parser
             mb_internal_encoding($mbEncoding);
         }
 
+        if ($objectForMap && !is_object($data) && 'mapping' === $context) {
+            $object = new \stdClass();
+
+            foreach ($data as $key => $value) {
+                $object->$key = $value;
+            }
+
+            $data = $object;
+        }
+
         return empty($data) ? null : $data;
     }
 
@@ -337,6 +349,11 @@ class Parser
     private function getNextEmbedBlock($indentation = null, $inSequence = false)
     {
         $oldLineIndentation = $this->getCurrentLineIndentation();
+        $blockScalarIndentations = array();
+
+        if ($this->isBlockScalarHeader()) {
+            $blockScalarIndentations[] = $this->getCurrentLineIndentation();
+        }
 
         if (!$this->moveToNextLine()) {
             return;
@@ -345,7 +362,7 @@ class Parser
         if (null === $indentation) {
             $newIndent = $this->getCurrentLineIndentation();
 
-            $unindentedEmbedBlock = $this->isStringUnIndentedCollectionItem($this->currentLine);
+            $unindentedEmbedBlock = $this->isStringUnIndentedCollectionItem();
 
             if (!$this->isCurrentLineEmpty() && 0 === $newIndent && !$unindentedEmbedBlock) {
                 throw new ParseException('Indentation problem.', $this->getRealCurrentLineNb() + 1, $this->currentLine);
@@ -371,20 +388,33 @@ class Parser
             return;
         }
 
-        $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem($this->currentLine);
+        $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem();
 
-        // Comments must not be removed inside a string block (ie. after a line ending with "|")
-        $removeCommentsPattern = '~'.self::FOLDED_SCALAR_PATTERN.'$~';
-        $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
+        if (empty($blockScalarIndentations) && $this->isBlockScalarHeader()) {
+            $blockScalarIndentations[] = $this->getCurrentLineIndentation();
+        }
+
+        $previousLineIndentation = $this->getCurrentLineIndentation();
 
         while ($this->moveToNextLine()) {
             $indent = $this->getCurrentLineIndentation();
 
-            if ($indent === $newIndent) {
-                $removeComments = !preg_match($removeCommentsPattern, $this->currentLine);
+            // terminate all block scalars that are more indented than the current line
+            if (!empty($blockScalarIndentations) && $indent < $previousLineIndentation && trim($this->currentLine) !== '') {
+                foreach ($blockScalarIndentations as $key => $blockScalarIndentation) {
+                    if ($blockScalarIndentation >= $this->getCurrentLineIndentation()) {
+                        unset($blockScalarIndentations[$key]);
+                    }
+                }
             }
 
-            if ($isItUnindentedCollection && !$this->isStringUnIndentedCollectionItem($this->currentLine) && $newIndent === $indent) {
+            if (empty($blockScalarIndentations) && !$this->isCurrentLineComment() && $this->isBlockScalarHeader()) {
+                $blockScalarIndentations[] = $this->getCurrentLineIndentation();
+            }
+
+            $previousLineIndentation = $indent;
+
+            if ($isItUnindentedCollection && !$this->isStringUnIndentedCollectionItem() && $newIndent === $indent) {
                 $this->moveToPreviousLine();
                 break;
             }
@@ -394,7 +424,8 @@ class Parser
                 continue;
             }
 
-            if ($removeComments && $this->isCurrentLineComment()) {
+            // we ignore "comment" lines only when we are not inside a scalar block
+            if (empty($blockScalarIndentations) && $this->isCurrentLineComment()) {
                 continue;
             }
 
@@ -443,12 +474,13 @@ class Parser
      * @param bool   $exceptionOnInvalidType True if an exception must be thrown on invalid types false otherwise
      * @param bool   $objectSupport          True if object support is enabled, false otherwise
      * @param bool   $objectForMap           true if maps should return a stdClass instead of array()
+     * @param string $context                The parser context (either sequence or mapping)
      *
      * @return mixed A PHP value
      *
      * @throws ParseException When reference does not exist
      */
-    private function parseValue($value, $exceptionOnInvalidType, $objectSupport, $objectForMap)
+    private function parseValue($value, $exceptionOnInvalidType, $objectSupport, $objectForMap, $context)
     {
         if (0 === strpos($value, '*')) {
             if (false !== $pos = strpos($value, '#')) {
@@ -464,14 +496,23 @@ class Parser
             return $this->refs[$value];
         }
 
-        if (preg_match('/^'.self::FOLDED_SCALAR_PATTERN.'$/', $value, $matches)) {
+        if (preg_match('/^'.self::BLOCK_SCALAR_HEADER_PATTERN.'$/', $value, $matches)) {
             $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-            return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+            return $this->parseBlockScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
         }
 
         try {
-            return Inline::parse($value, $exceptionOnInvalidType, $objectSupport, $objectForMap, $this->refs);
+            $parsedValue = Inline::parse($value, $exceptionOnInvalidType, $objectSupport, $objectForMap, $this->refs);
+
+            if ('mapping' === $context && '"' !== $value[0] && "'" !== $value[0] && '[' !== $value[0] && '{' !== $value[0] && '!' !== $value[0] && false !== strpos($parsedValue, ': ')) {
+                @trigger_error(sprintf('Using a colon in the unquoted mapping value "%s" in line %d is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $value, $this->getRealCurrentLineNb() + 1), E_USER_DEPRECATED);
+
+                // to be thrown in 3.0
+                // throw new ParseException('A colon cannot be used in an unquoted mapping value.');
+            }
+
+            return $parsedValue;
         } catch (ParseException $e) {
             $e->setParsedLine($this->getRealCurrentLineNb() + 1);
             $e->setSnippet($this->currentLine);
@@ -481,15 +522,15 @@ class Parser
     }
 
     /**
-     * Parses a folded scalar.
+     * Parses a block scalar.
      *
-     * @param string $separator   The separator that was used to begin this folded scalar (| or >)
-     * @param string $indicator   The indicator that was used to begin this folded scalar (+ or -)
-     * @param int    $indentation The indentation that was used to begin this folded scalar
+     * @param string $style       The style indicator that was used to begin this block scalar (| or >)
+     * @param string $chomping    The chomping indicator that was used to begin this block scalar (+ or -)
+     * @param int    $indentation The indentation indicator that was used to begin this block scalar
      *
      * @return string The text value
      */
-    private function parseFoldedScalar($separator, $indicator = '', $indentation = 0)
+    private function parseBlockScalar($style, $chomping = '', $indentation = 0)
     {
         $notEOF = $this->moveToNextLine();
         if (!$notEOF) {
@@ -497,13 +538,13 @@ class Parser
         }
 
         $isCurrentLineBlank = $this->isCurrentLineBlank();
-        $text = '';
+        $blockLines = array();
 
         // leading blank lines are consumed before determining indentation
         while ($notEOF && $isCurrentLineBlank) {
             // newline only if not EOF
             if ($notEOF = $this->moveToNextLine()) {
-                $text .= "\n";
+                $blockLines[] = '';
                 $isCurrentLineBlank = $this->isCurrentLineBlank();
             }
         }
@@ -524,37 +565,65 @@ class Parser
                     preg_match($pattern, $this->currentLine, $matches)
                 )
             ) {
-                if ($isCurrentLineBlank) {
-                    $text .= substr($this->currentLine, $indentation);
+                if ($isCurrentLineBlank && strlen($this->currentLine) > $indentation) {
+                    $blockLines[] = substr($this->currentLine, $indentation);
+                } elseif ($isCurrentLineBlank) {
+                    $blockLines[] = '';
                 } else {
-                    $text .= $matches[1];
+                    $blockLines[] = $matches[1];
                 }
 
                 // newline only if not EOF
                 if ($notEOF = $this->moveToNextLine()) {
-                    $text .= "\n";
                     $isCurrentLineBlank = $this->isCurrentLineBlank();
                 }
             }
         } elseif ($notEOF) {
-            $text .= "\n";
+            $blockLines[] = '';
         }
 
         if ($notEOF) {
+            $blockLines[] = '';
             $this->moveToPreviousLine();
         }
 
-        // replace all non-trailing single newlines with spaces in folded blocks
-        if ('>' === $separator) {
-            preg_match('/(\n*)$/', $text, $matches);
-            $text = preg_replace('/(?<!\n)\n(?!\n)/', ' ', rtrim($text, "\n"));
-            $text .= $matches[1];
+        // folded style
+        if ('>' === $style) {
+            $text = '';
+            $previousLineIndented = false;
+            $previousLineBlank = false;
+
+            for ($i = 0; $i < count($blockLines); ++$i) {
+                if ('' === $blockLines[$i]) {
+                    $text .= "\n";
+                    $previousLineIndented = false;
+                    $previousLineBlank = true;
+                } elseif (' ' === $blockLines[$i][0]) {
+                    $text .= "\n".$blockLines[$i];
+                    $previousLineIndented = true;
+                    $previousLineBlank = false;
+                } elseif ($previousLineIndented) {
+                    $text .= "\n".$blockLines[$i];
+                    $previousLineIndented = false;
+                    $previousLineBlank = false;
+                } elseif ($previousLineBlank || 0 === $i) {
+                    $text .= $blockLines[$i];
+                    $previousLineIndented = false;
+                    $previousLineBlank = false;
+                } else {
+                    $text .= ' '.$blockLines[$i];
+                    $previousLineIndented = false;
+                    $previousLineBlank = false;
+                }
+            }
+        } else {
+            $text = implode("\n", $blockLines);
         }
 
-        // deal with trailing newlines as indicated
-        if ('' === $indicator) {
+        // deal with trailing newlines
+        if ('' === $chomping) {
             $text = preg_replace('/\n+$/', "\n", $text);
-        } elseif ('-' === $indicator) {
+        } elseif ('-' === $chomping) {
             $text = preg_replace('/\n+$/', '', $text);
         }
 
@@ -619,7 +688,7 @@ class Parser
         //checking explicitly the first char of the trim is faster than loops or strpos
         $ltrimmedLine = ltrim($this->currentLine, ' ');
 
-        return $ltrimmedLine[0] === '#';
+        return '' !== $ltrimmedLine && $ltrimmedLine[0] === '#';
     }
 
     /**
@@ -682,7 +751,7 @@ class Parser
         if (
             $this->getCurrentLineIndentation() == $currentIndentation
             &&
-            $this->isStringUnIndentedCollectionItem($this->currentLine)
+            $this->isStringUnIndentedCollectionItem()
         ) {
             $ret = true;
         }
@@ -699,6 +768,16 @@ class Parser
      */
     private function isStringUnIndentedCollectionItem()
     {
-        return (0 === strpos($this->currentLine, '- '));
+        return 0 === strpos($this->currentLine, '- ');
+    }
+
+    /**
+     * Tests whether or not the current line is the header of a block scalar.
+     *
+     * @return bool
+     */
+    private function isBlockScalarHeader()
+    {
+        return (bool) preg_match('~'.self::BLOCK_SCALAR_HEADER_PATTERN.'$~', $this->currentLine);
     }
 }

--- a/vendor/symfony/yaml/Tests/DumperTest.php
+++ b/vendor/symfony/yaml/Tests/DumperTest.php
@@ -54,7 +54,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     {
         $this->dumper->setIndentation(7);
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -103,13 +103,13 @@ EOF;
 
     public function testInlineLevel()
     {
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 { '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -119,7 +119,7 @@ foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 1), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -134,7 +134,7 @@ foobar:
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 2), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -153,7 +153,7 @@ foobar:
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 3), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -180,7 +180,7 @@ EOF;
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, false, true);
 
-        $this->assertEquals('{ foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
+        $this->assertEquals('{ foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
     }
 
     public function testObjectSupportDisabledButNoExceptions()

--- a/vendor/symfony/yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -515,7 +515,7 @@ yaml: |
 php: |
   array(
     'canonical' => 12345,
-    'decimal' => 12345,
+    'decimal' => 12345.0,
     'octal' => 014,
     'hexadecimal' => 0xC
   )
@@ -754,7 +754,7 @@ yaml: |
     Billsmer @ 338-4338.
 php: |
   array(
-     'invoice' => 34843, 'date' => mktime(0, 0, 0, 1, 23, 2001),
+     'invoice' => 34843, 'date' => gmmktime(0, 0, 0, 1, 23, 2001),
      'bill-to' =>
       array( 'given' => 'Chris', 'family' => 'Dumars', 'address' => array( 'lines' => "458 Walkman Dr.\nSuite #292\n", 'city' => 'Royal Oak', 'state' => 'MI', 'postal' => 48046 ) )
      , 'ship-to' =>
@@ -879,7 +879,7 @@ yaml: |
 php: |
    array(
       'invoice' => 34843,
-      'date' => mktime(0, 0, 0, 1, 23, 2001),
+      'date' => gmmktime(0, 0, 0, 1, 23, 2001),
       'total' => 4443.52
    )
 ---
@@ -1538,7 +1538,7 @@ yaml: |
 php: |
    array(
      'canonical' => 12345,
-     'decimal' => 12345,
+     'decimal' => 12345.0,
      'octal' => 12,
      'hexadecimal' => 12
    )

--- a/vendor/symfony/yaml/Tests/Fixtures/YtsTypeTransfers.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/YtsTypeTransfers.yml
@@ -182,8 +182,8 @@ php: |
     array(
       'zero' => 0,
       'simple' => 12,
-      'one-thousand' => 1000,
-      'negative one-thousand' => -1000
+      'one-thousand' => 1000.0,
+      'negative one-thousand' => -1000.0
     )
 ---
 test: Integers as Map Keys

--- a/vendor/symfony/yaml/Tests/Fixtures/escapedCharacters.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/escapedCharacters.yml
@@ -145,3 +145,11 @@ php: |
     array(
         'double' => "some value\n \"some quoted string\" and 'some single quotes one'"
     )
+---
+test: Backslashes
+yaml: |
+    { single: 'foo\Var', no-quotes: foo\Var, double: "foo\\Var" }
+php: |
+    array(
+        'single' => 'foo\Var', 'no-quotes' => 'foo\Var', 'double' => 'foo\Var'
+    )

--- a/vendor/symfony/yaml/Tests/Fixtures/sfComments.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/sfComments.yml
@@ -7,8 +7,11 @@ yaml: |
     ex2: "foo # bar" # comment
     ex3: 'foo # bar' # comment
     ex4: foo # comment
+    ex5: foo	#	comment with tab before  
+    ex6: foo#foo # comment here
+    ex7: foo 	# ignore me # and me
 php: |
-    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo')
+    array('ex1' => 'foo # bar', 'ex2' => 'foo # bar', 'ex3' => 'foo # bar', 'ex4' => 'foo', 'ex5' => 'foo', 'ex6' => 'foo#foo', 'ex7' => 'foo')
 ---
 test: Comments in the middle
 brief: >

--- a/vendor/symfony/yaml/Tests/Fixtures/sfQuotes.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/sfQuotes.yml
@@ -3,7 +3,7 @@ test: Some characters at the beginning of a string must be escaped
 brief: >
     Some characters at the beginning of a string must be escaped
 yaml: |
-    foo: | bar
+    foo: '| bar'
 php: |
     array('foo' => '| bar')
 ---

--- a/vendor/symfony/yaml/Tests/Fixtures/sfTests.yml
+++ b/vendor/symfony/yaml/Tests/Fixtures/sfTests.yml
@@ -51,9 +51,9 @@ php: |
       '~',
     )
 ---
-test: Empty lines in folded blocks
+test: Empty lines in literal blocks
 brief: >
-  Empty lines in folded blocks
+  Empty lines in literal blocks
 yaml: |
   foo:
     bar: |
@@ -64,6 +64,20 @@ yaml: |
       bar
 php: |
   array('foo' => array('bar' => "foo\n\n\n  \nbar\n"))
+---
+test: Empty lines in folded blocks
+brief: >
+  Empty lines in folded blocks
+yaml: |
+  foo:
+    bar: >
+
+      foo
+
+      
+      bar
+php: |
+  array('foo' => array('bar' => "\nfoo\n\nbar\n"))
 ---
 test: IP addresses
 brief: >

--- a/vendor/symfony/yaml/Tests/InlineTest.php
+++ b/vendor/symfony/yaml/Tests/InlineTest.php
@@ -73,6 +73,23 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 3.0
+     */
+    public function testParseScalarWithNonEscapedBlackslashShouldThrowException()
+    {
+        $this->assertSame('Foo\Var', Inline::parse('"Foo\Var"'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseScalarWithNonEscapedBlackslashAtTheEndShouldThrowException()
+    {
+        Inline::parse('"Foo\\"');
+    }
+
+    /**
      * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */
     public function testParseScalarWithIncorrectlyQuotedStringShouldThrowException()
@@ -173,6 +190,36 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         Inline::parse('{ foo: * #foo }');
     }
 
+    /**
+     * @group legacy
+     * @dataProvider getReservedIndicators
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 3.0
+     */
+    public function testParseUnquotedScalarStartingWithReservedIndicator($indicator)
+    {
+        Inline::parse(sprintf('{ foo: %sfoo }', $indicator));
+    }
+
+    public function getReservedIndicators()
+    {
+        return array(array('@'), array('`'));
+    }
+
+    /**
+     * @group legacy
+     * @dataProvider getScalarIndicators
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 3.0
+     */
+    public function testParseUnquotedScalarStartingWithScalarIndicator($indicator)
+    {
+        Inline::parse(sprintf('{ foo: %sfoo }', $indicator));
+    }
+
+    public function getScalarIndicators()
+    {
+        return array(array('|'), array('>'));
+    }
+
     public function getTestsForParse()
     {
         return array(
@@ -206,7 +253,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             array("'on'", 'on'),
             array("'off'", 'off'),
 
-            array('2007-10-30', mktime(0, 0, 0, 10, 30, 2007)),
+            array('2007-10-30', gmmktime(0, 0, 0, 10, 30, 2007)),
             array('2007-10-30T02:59:43Z', gmmktime(2, 59, 43, 10, 30, 2007)),
             array('2007-10-30 02:59:43 Z', gmmktime(2, 59, 43, 10, 30, 2007)),
             array('1960-10-30 02:59:43 Z', gmmktime(2, 59, 43, 10, 30, 1960)),
@@ -273,7 +320,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             array("'#cfcfcf'", '#cfcfcf'),
             array('::form_base.html.twig', '::form_base.html.twig'),
 
-            array('2007-10-30', mktime(0, 0, 0, 10, 30, 2007)),
+            array('2007-10-30', gmmktime(0, 0, 0, 10, 30, 2007)),
             array('2007-10-30T02:59:43Z', gmmktime(2, 59, 43, 10, 30, 2007)),
             array('2007-10-30 02:59:43 Z', gmmktime(2, 59, 43, 10, 30, 2007)),
             array('1960-10-30 02:59:43 Z', gmmktime(2, 59, 43, 10, 30, 1960)),

--- a/vendor/symfony/yaml/Tests/ParserTest.php
+++ b/vendor/symfony/yaml/Tests/ParserTest.php
@@ -90,7 +90,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testEndOfTheDocumentMarker()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 --- %YAML:1.0
 foo
 ...
@@ -426,34 +426,124 @@ foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
         $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($input, false, true), '->parse() is able to parse objects');
-    }
 
-    public function testObjectSupportDisabledButNoExceptions()
-    {
         $input = <<<EOF
-foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
+foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
+        $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($input, false, true), '->parse() is able to parse objects');
+    }
 
+    /**
+     * @dataProvider invalidDumpedObjectProvider
+     */
+    public function testObjectSupportDisabledButNoExceptions($input)
+    {
         $this->assertEquals(array('foo' => null, 'bar' => 1), $this->parser->parse($input), '->parse() does not parse objects');
     }
 
     /**
-     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @dataProvider getObjectForMapTests
      */
-    public function testObjectsSupportDisabledWithExceptions()
+    public function testObjectForMap($yaml, $expected)
     {
-        $this->parser->parse('foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, false);
+        $this->assertEquals($expected, $this->parser->parse($yaml, false, false, true));
     }
 
+    public function getObjectForMapTests()
+    {
+        $tests = array();
+
+        $yaml = <<<EOF
+foo:
+    fiz: [cat]
+EOF;
+        $expected = new \stdClass();
+        $expected->foo = new \stdClass();
+        $expected->foo->fiz = array('cat');
+        $tests['mapping'] = array($yaml, $expected);
+
+        $yaml = '{ "foo": "bar", "fiz": "cat" }';
+        $expected = new \stdClass();
+        $expected->foo = 'bar';
+        $expected->fiz = 'cat';
+        $tests['inline-mapping'] = array($yaml, $expected);
+
+        $yaml = "foo: bar\nbaz: foobar";
+        $expected = new \stdClass();
+        $expected->foo = 'bar';
+        $expected->baz = 'foobar';
+        $tests['object-for-map-is-applied-after-parsing'] = array($yaml, $expected);
+
+        $yaml = <<<EOT
+array:
+  - key: one
+  - key: two
+EOT;
+        $expected = new \stdClass();
+        $expected->array = array();
+        $expected->array[0] = new \stdClass();
+        $expected->array[0]->key = 'one';
+        $expected->array[1] = new \stdClass();
+        $expected->array[1]->key = 'two';
+        $tests['nest-map-and-sequence'] = array($yaml, $expected);
+
+        $yaml = <<<YAML
+map:
+  1: one
+  2: two
+YAML;
+        $expected = new \stdClass();
+        $expected->map = new \stdClass();
+        $expected->map->{1} = 'one';
+        $expected->map->{2} = 'two';
+        $tests['numeric-keys'] = array($yaml, $expected);
+
+        $yaml = <<<YAML
+map:
+  0: one
+  1: two
+YAML;
+        $expected = new \stdClass();
+        $expected->map = new \stdClass();
+        $expected->map->{0} = 'one';
+        $expected->map->{1} = 'two';
+        $tests['zero-indexed-numeric-keys'] = array($yaml, $expected);
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider invalidDumpedObjectProvider
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testObjectsSupportDisabledWithExceptions($yaml)
+    {
+        $this->parser->parse($yaml, true, false);
+    }
+
+    public function invalidDumpedObjectProvider()
+    {
+        $yamlTag = <<<EOF
+foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
+bar: 1
+EOF;
+        $localTag = <<<EOF
+foo: !php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
+bar: 1
+EOF;
+
+        return array(
+            'yaml-tag' => array($yamlTag),
+            'local-tag' => array($localTag),
+        );
+    }
+
+    /**
+     * @requires extension iconv
+     */
     public function testNonUtf8Exception()
     {
-        if (!function_exists('iconv')) {
-            $this->markTestSkipped('Exceptions for non-utf8 charsets require the iconv() function.');
-
-            return;
-        }
-
         $yamls = array(
             iconv('UTF-8', 'ISO-8859-1', "foo: 'äöüß'"),
             iconv('UTF-8', 'ISO-8859-15', "euro: '€'"),
@@ -476,7 +566,7 @@ EOF;
      */
     public function testUnindentedCollectionException()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 
 collection:
 -item1
@@ -493,7 +583,7 @@ EOF;
      */
     public function testShortcutKeyUnindentedCollectionException()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 
 collection:
 -  key: foo
@@ -510,7 +600,7 @@ EOF;
      */
     public function testMultipleDocumentsNotSupportedException()
     {
-        Yaml::parse(<<<EOL
+        Yaml::parse(<<<'EOL'
 # Ranking of 1998 home runs
 ---
 - Mark McGwire
@@ -530,7 +620,7 @@ EOL
      */
     public function testSequenceInAMapping()
     {
-        Yaml::parse(<<<EOF
+        Yaml::parse(<<<'EOF'
 yaml:
   hash: me
   - array stuff
@@ -543,7 +633,7 @@ EOF
      */
     public function testMappingInASequence()
     {
-        Yaml::parse(<<<EOF
+        Yaml::parse(<<<'EOF'
 yaml:
   - array stuff
   hash: me
@@ -575,8 +665,6 @@ EOF
      *
      * @see http://yaml.org/spec/1.2/spec.html#id2759572
      * @see http://yaml.org/spec/1.1/#id932806
-     *
-     * @covers \Symfony\Component\Yaml\Parser::parse
      */
     public function testMappingDuplicateKeyBlock()
     {
@@ -596,9 +684,6 @@ EOD;
         $this->assertSame($expected, Yaml::parse($input));
     }
 
-    /**
-     * @covers \Symfony\Component\Yaml\Inline::parseMapping
-     */
     public function testMappingDuplicateKeyFlow()
     {
         $input = <<<EOD
@@ -615,16 +700,42 @@ EOD;
 
     public function testEmptyValue()
     {
-        $input = <<<EOF
+        $input = <<<'EOF'
 hash:
 EOF;
 
         $this->assertEquals(array('hash' => null), Yaml::parse($input));
     }
 
+    public function testCommentAtTheRootIndent()
+    {
+        $this->assertEquals(array(
+            'services' => array(
+                'app.foo_service' => array(
+                    'class' => 'Foo',
+                ),
+                'app/bar_service' => array(
+                    'class' => 'Bar',
+                ),
+            ),
+        ), Yaml::parse(<<<'EOF'
+# comment 1
+services:
+# comment 2
+    # comment 3
+    app.foo_service:
+        class: Foo
+# comment 4
+    # comment 5
+    app/bar_service:
+        class: Bar
+EOF
+        ));
+    }
+
     public function testStringBlockWithComments()
     {
-        $this->assertEquals(array('content' => <<<EOT
+        $this->assertEquals(array('content' => <<<'EOT'
 # comment 1
 header
 
@@ -635,7 +746,7 @@ header
 
 footer # comment3
 EOT
-        ), Yaml::parse(<<<EOF
+        ), Yaml::parse(<<<'EOF'
 content: |
     # comment 1
     header
@@ -652,7 +763,7 @@ EOF
 
     public function testFoldedStringBlockWithComments()
     {
-        $this->assertEquals(array(array('content' => <<<EOT
+        $this->assertEquals(array(array('content' => <<<'EOT'
 # comment 1
 header
 
@@ -663,7 +774,7 @@ header
 
 footer # comment3
 EOT
-        )), Yaml::parse(<<<EOF
+        )), Yaml::parse(<<<'EOF'
 -
     content: |
         # comment 1
@@ -683,7 +794,7 @@ EOF
     {
         $this->assertEquals(array(array(
             'title' => 'some title',
-            'content' => <<<EOT
+            'content' => <<<'EOT'
 # comment 1
 header
 
@@ -694,7 +805,7 @@ header
 
 footer # comment3
 EOT
-        )), Yaml::parse(<<<EOF
+        )), Yaml::parse(<<<'EOF'
 -
     title: some title
     content: |
@@ -723,7 +834,7 @@ EOF
             'map' => array('key' => 'var-value'),
             'list_in_map' => array('key' => array('var-value')),
             'map_in_map' => array('foo' => array('bar' => 'var-value')),
-        ), Yaml::parse(<<<EOF
+        ), Yaml::parse(<<<'EOF'
 var:  &var var-value
 scalar: *var
 list: [ *var ]
@@ -739,7 +850,7 @@ EOF
 
     public function testYamlDirective()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 %YAML 1.2
 ---
 foo: 1
@@ -750,7 +861,7 @@ EOF;
 
     public function testFloatKeys()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 foo:
     1.2: "bar"
     1.3: "baz"
@@ -764,6 +875,225 @@ EOF;
         );
 
         $this->assertEquals($expected, $this->parser->parse($yaml));
+    }
+
+    /**
+     * @group legacy
+     * throw ParseException in Symfony 3.0
+     */
+    public function testColonInMappingValueException()
+    {
+        $yaml = <<<EOF
+foo: bar: baz
+EOF;
+
+        $deprecations = array();
+        set_error_handler(function ($type, $msg) use (&$deprecations) {
+            if (E_USER_DEPRECATED === $type) {
+                $deprecations[] = $msg;
+            }
+        });
+
+        $this->parser->parse($yaml);
+
+        restore_error_handler();
+
+        $this->assertCount(1, $deprecations);
+        $this->assertContains('Using a colon in the unquoted mapping value "bar: baz" in line 1 is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $deprecations[0]);
+    }
+
+    public function testColonInMappingValueExceptionNotTriggeredByColonInComment()
+    {
+        $yaml = <<<EOT
+foo:
+    bar: foobar # Note: a comment after a colon
+EOT;
+
+        $this->assertSame(array('foo' => array('bar' => 'foobar')), $this->parser->parse($yaml));
+    }
+
+    /**
+     * @dataProvider getCommentLikeStringInScalarBlockData
+     */
+    public function testCommentLikeStringsAreNotStrippedInBlockScalars($yaml, $expectedParserResult)
+    {
+        $this->assertSame($expectedParserResult, $this->parser->parse($yaml));
+    }
+
+    public function getCommentLikeStringInScalarBlockData()
+    {
+        $tests = array();
+
+        $yaml = <<<'EOT'
+pages:
+    -
+        title: some title
+        content: |
+            # comment 1
+            header
+
+                # comment 2
+                <body>
+                    <h1>title</h1>
+                </body>
+
+            footer # comment3
+EOT;
+        $expected = array(
+            'pages' => array(
+                array(
+                    'title' => 'some title',
+                    'content' => <<<'EOT'
+# comment 1
+header
+
+    # comment 2
+    <body>
+        <h1>title</h1>
+    </body>
+
+footer # comment3
+EOT
+                    ,
+                ),
+            ),
+        );
+        $tests[] = array($yaml, $expected);
+
+        $yaml = <<<'EOT'
+test: |
+    foo
+    # bar
+    baz
+collection:
+    - one: |
+        foo
+        # bar
+        baz
+    - two: |
+        foo
+        # bar
+        baz
+EOT;
+        $expected = array(
+            'test' => <<<'EOT'
+foo
+# bar
+baz
+
+EOT
+            ,
+            'collection' => array(
+                array(
+                    'one' => <<<'EOT'
+foo
+# bar
+baz
+EOT
+                    ,
+                ),
+                array(
+                    'two' => <<<'EOT'
+foo
+# bar
+baz
+EOT
+                    ,
+                ),
+            ),
+        );
+        $tests[] = array($yaml, $expected);
+
+        $yaml = <<<EOT
+foo:
+  bar:
+    scalar-block: >
+      line1
+      line2>
+  baz:
+# comment
+    foobar: ~
+EOT;
+        $expected = array(
+            'foo' => array(
+                'bar' => array(
+                    'scalar-block' => 'line1 line2>',
+                ),
+                'baz' => array(
+                    'foobar' => null,
+                ),
+            ),
+        );
+        $tests[] = array($yaml, $expected);
+
+        $yaml = <<<'EOT'
+a:
+    b: hello
+#    c: |
+#        first row
+#        second row
+    d: hello
+EOT;
+        $expected = array(
+            'a' => array(
+                'b' => 'hello',
+                'd' => 'hello',
+            ),
+        );
+        $tests[] = array($yaml, $expected);
+
+        return $tests;
+    }
+
+    public function testBlankLinesAreParsedAsNewLinesInFoldedBlocks()
+    {
+        $yaml = <<<EOT
+test: >
+    <h2>A heading</h2>
+
+    <ul>
+    <li>a list</li>
+    <li>may be a good example</li>
+    </ul>
+EOT;
+
+        $this->assertSame(
+            array(
+                'test' => <<<EOT
+<h2>A heading</h2>
+<ul> <li>a list</li> <li>may be a good example</li> </ul>
+EOT
+                ,
+            ),
+            $this->parser->parse($yaml)
+        );
+    }
+
+    public function testAdditionallyIndentedLinesAreParsedAsNewLinesInFoldedBlocks()
+    {
+        $yaml = <<<EOT
+test: >
+    <h2>A heading</h2>
+
+    <ul>
+      <li>a list</li>
+      <li>may be a good example</li>
+    </ul>
+EOT;
+
+        $this->assertSame(
+            array(
+                'test' => <<<EOT
+<h2>A heading</h2>
+<ul>
+  <li>a list</li>
+  <li>may be a good example</li>
+</ul>
+EOT
+                ,
+            ),
+            $this->parser->parse($yaml)
+        );
     }
 }
 

--- a/vendor/symfony/yaml/Unescaper.php
+++ b/vendor/symfony/yaml/Unescaper.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Yaml;
  * YAML strings.
  *
  * @author Matthew Lewinski <matthew@lewinski.org>
+ *
+ * @internal
  */
 class Unescaper
 {
@@ -32,7 +34,7 @@ class Unescaper
     /**
      * Regex fragment that matches an escaped character in a double quoted string.
      */
-    const REGEX_ESCAPED_CHARACTER = "\\\\([0abt\tnvfre \\\"\\/\\\\N_LP]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})";
+    const REGEX_ESCAPED_CHARACTER = '\\\\(x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|.)';
 
     /**
      * Unescapes a single quoted string.
@@ -70,10 +72,13 @@ class Unescaper
      * @param string $value An escaped character
      *
      * @return string The unescaped character
+     *
+     * @internal This method is public to be usable as callback. It should not
+     *           be used in user code. Should be changed in 3.0.
      */
     public function unescapeCharacter($value)
     {
-        switch ($value{1}) {
+        switch ($value[1]) {
             case '0':
                 return "\x0";
             case 'a':
@@ -120,6 +125,10 @@ class Unescaper
                 return self::utf8chr(hexdec(substr($value, 2, 4)));
             case 'U':
                 return self::utf8chr(hexdec(substr($value, 2, 8)));
+            default:
+                @trigger_error('Not escaping a backslash in a double-quoted string is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', E_USER_DEPRECATED);
+
+                return $value;
         }
     }
 

--- a/vendor/symfony/yaml/Yaml.php
+++ b/vendor/symfony/yaml/Yaml.php
@@ -17,16 +17,11 @@ use Symfony\Component\Yaml\Exception\ParseException;
  * Yaml offers convenience methods to load and dump YAML.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 class Yaml
 {
     /**
-     * Parses YAML into a PHP array.
-     *
-     * The parse method, when supplied with a YAML stream (string or file),
-     * will do its best to convert YAML in a file into a PHP array.
+     * Parses YAML into a PHP value.
      *
      *  Usage:
      *  <code>
@@ -45,11 +40,9 @@ class Yaml
      * @param bool   $objectSupport          True if object support is enabled, false otherwise
      * @param bool   $objectForMap           True if maps should return a stdClass instead of array()
      *
-     * @return array The YAML converted to a PHP array
+     * @return mixed The YAML converted to a PHP value
      *
      * @throws ParseException If the YAML is not valid
-     *
-     * @api
      */
     public static function parse($input, $exceptionOnInvalidType = false, $objectSupport = false, $objectForMap = false)
     {
@@ -92,8 +85,6 @@ class Yaml
      * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
      * @return string A YAML string representing the original PHP array
-     *
-     * @api
      */
     public static function dump($array, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
     {

--- a/vendor/symfony/yaml/composer.json
+++ b/vendor/symfony/yaml/composer.json
@@ -18,16 +18,16 @@
     "require": {
         "php": ">=5.3.9"
     },
-    "require-dev": {
-        "symfony/phpunit-bridge": "~2.7"
-    },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\Yaml\\": "" }
+        "psr-4": { "Symfony\\Component\\Yaml\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "2.8-dev"
         }
     }
 }

--- a/vendor/symfony/yaml/phpunit.xml.dist
+++ b/vendor/symfony/yaml/phpunit.xml.dist
@@ -20,8 +20,8 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./vendor</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
### Description

This is the first step to solve #557 and will help with a lot of current features like upload, drag n'drop and sharing.

What it does is send a bit more meta data about each file, but a lot more about sub-albums (`fileId, mTime, etag, size, sharedWithUser, owner, freeSpace, permissions`).

The change is quite large, so test thoroughly.
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
### Test plan
#### Setup
- Blacklist some albums
- Have some deeply nested albums
#### Actions
- Test both the logged-in and public side as internal paths are different
- Navigate to and out of folders
- Upload files and folder
- Move files and folder around
### Tech review
- Instead of sending a list of nodes and letting the client parse it to extract albums and files, the backend sends a array for each
- `$privacyChecker` has been renamed `$ignoreAlbum` as the blacklist feature is just a filter for the view
- The backend doesn't let the client know if the location has changed any more. The client simply compares the path it's sent with the one it receives
- Every answer to a request for files will let the client know if the content has changed (bool)
- `item-source` is made available to `share.js`
### Check list
- [x] Code is properly documented
- [x] Commits have been squashed
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@jospoortvliet @setnes @demattin @arkascha @elpraga @sualko @bugsbane @mmattel @tahaalibra @viraj96 @imjalpreet @mbtamuli @rahulgoyal030
