### PR TITLE
Only show sort buttons if there is more than 1 image in the album

### DIFF
--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -233,8 +233,19 @@
 			var availableWidth = $(window).width() - Gallery.buttonsWidth;
 			this.breadcrumb.init(albumPath, availableWidth);
 			var album = Gallery.albumMap[albumPath];
-			
-			var sum = album.images.length + album.subAlbums.length;
+			var sum = 0;
+			if(!_.isUndefined(album.images) && !_.isUndefined(album.subAlbums))
+			{
+				sum = album.images.length + album.subAlbums.length;
+			}
+			else if(_.isUndefined(album.images) && !_.isUndefined(album.subAlbums))
+			{
+				sum = album.subAlbums.length;	
+			}
+			else if(!_.isUndefined(album.images) && _.isUndefined(album.subAlbums))
+			{
+				sum = album.images.length;
+			}
 			//If sum of the number of images and subalbums exceeds 1 then show the buttons.
 			if(sum > 1)
 			{


### PR DESCRIPTION
Fixes: #573 

Licence: AGPL
### Description

Sorted buttons only show up when there is more than one image or folder in the gallery.
### Features

Added  checks to ensure that no typeError problems occur due to usage of `album.images` or `album.subAlbums`.
### Tested on
- [X] Ubuntu 14.04/Chrome
### TODO

Inorder to test,
- [1]  Add a .nomedia file to folder which has a parent folder.
- [2]  Switch to Gallery.
- [3]  Press on the parent folder on the breadcrumb.

Then, ensure no typeError problem is coming.
### Reviewers

@oparoz 
