### PR TITLE
Build the albumMap even when the server returns a 403

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -93,7 +93,9 @@
 
 			}, function (xhr) {
 				var result = xhr.responseJSON;
-				Gallery.view.init(decodeURIComponent(currentLocation), result.message);
+				var albumPath = decodeURIComponent(currentLocation);
+				Gallery.view.init(albumPath, result.message);
+				Gallery._mapStructure(albumPath);
 			});
 		},
 


### PR DESCRIPTION
### Description

Album navigation breaks when the starting point is an empty Gallery and the user moves to the parent folder.
That's because the map we use for navigation is not built when the server returns an error status to a getFiles request.
#### Steps to reproduce
1. Add pictures to a folder
2. Create a sub-folder
3. Enter the sub-folder
4. Add a `.nomedia` file
5. Switch to Gallery
6. Press on the parent folder in the breadcrumb
#### Result before

```
TypeError: album.images is undefined  in galleryview.js
```
#### Result with this PR

No error
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
### Reviewers

@tahaalibra @viraj96 @imjalpreet @mbtamuli @rahulgoyal030
