### PR TITLE
Close the share dialogue when performing another action, fixes #545

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -48,10 +48,3 @@ body {
 #gallery.hascontrols {
 	padding-bottom: 0;
 }
-
-#loading-indicator {
-	height: 32px;
-	width: 100%;
-	margin-top: 100px;
-	margin-bottom: 0;
-}

--- a/css/styles.css
+++ b/css/styles.css
@@ -100,7 +100,8 @@ div.crumb.last a {
 	vertical-align: top;
 }
 
-#gallery .row > .album-container > .album-loader {
+#gallery .row > .album-container > .album-loader,
+#gallery .row > .image-container > .image-loader{
 	position: absolute;
 	z-index: 11;
 	top: 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -87,11 +87,11 @@ div.crumb.last a {
 	margin-top: 2px;
 }
 
-#gallery .row .item-container:first-child {
+#gallery .row a:first-child {
 	margin-left: 4px;
 }
 
-#gallery .row > .item-container {
+#gallery .row > a {
 	position: relative;
 	display: inline-block;
 	height: auto;
@@ -100,8 +100,13 @@ div.crumb.last a {
 	vertical-align: top;
 }
 
-#gallery .row > .album-container > .album-loader,
-#gallery .row > .image-container > .image-loader{
+#gallery .row > a .container {
+	-webkit-transition: all .2s ease-in-out;
+	transition: all .2s ease-in-out;
+}
+
+#gallery .row > a > .album-loader,
+#gallery .row > a > .image-loader {
 	position: absolute;
 	z-index: 11;
 	top: 0;
@@ -110,7 +115,7 @@ div.crumb.last a {
 	right: 0;
 }
 
-#gallery .item-container .album-label {
+#gallery .row > a > .album-label {
 	color: #fff;
 	position: absolute;
 	left: 0;
@@ -126,7 +131,7 @@ div.crumb.last a {
 	z-index: 11;
 }
 
-#gallery .item-container .image-label {
+#gallery .row > a > .image-label {
 	display: none;
 	position: absolute;
 	left: 0;
@@ -139,12 +144,12 @@ div.crumb.last a {
 	word-break: break-all;
 }
 
-#gallery .item-container .album-label,
-#gallery .item-container .image-label {
+#gallery .row > a > .album-label,
+#gallery .row > a > .image-label {
 	background: rgba(0, 0, 0, 0.4);
 }
 
-#gallery .item-container .image-label .title {
+#gallery .row > a > .image-label .title {
 	display: inline-block;
 	color: #fff;
 	text-align: center;
@@ -156,12 +161,12 @@ div.crumb.last a {
 	text-overflow: ellipsis;
 }
 
-#gallery .item-container .image-label .title:hover {
+#gallery .row > a > .image-label .title:hover {
 	overflow: visible;
 	white-space: normal;
 }
 
-#gallery a.album > img {
+#gallery .row > a > .album > img {
 	max-width: 200px;
 	max-height: 200px;
 	position: relative;
@@ -169,27 +174,13 @@ div.crumb.last a {
 	margin: 1px;
 }
 
-#gallery a {
-	display: inline-block;
-	margin: 0;
-	position: relative;
-	vertical-align: top;
-	*display: inline;
-	zoom: 1;
-}
-
 /* make focus visible for keyboard users */
-#gallery a:focus,
-#gallery a.album:focus {
+#gallery .row > a:focus,
+#gallery .row > a > .album:focus {
 	opacity: .5;
 }
 
-#gallery a {
-	-webkit-transition: all .2s ease-in-out;
-	transition: all .2s ease-in-out;
-}
-
-#gallery a.image > img {
+#gallery .row > a .image > img {
 	max-height: 200px;
 }
 
@@ -200,7 +191,7 @@ div.crumb.last a {
 	transition: opacity 500ms;
 }
 
-#gallery a.album .cropped {
+#gallery .row > a .album .cropped {
 	position: relative;
 	float: left;
 	margin: 1px;
@@ -208,8 +199,8 @@ div.crumb.last a {
 	background-size: cover;
 }
 
-#gallery a.album .icon-loading,
-#gallery .image-container .icon-loading {
+#gallery .row > a .album .icon-loading,
+#gallery .row > a .icon-loading {
 	margin: auto;
 	position: absolute;
 	top: 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -183,13 +183,18 @@ div.crumb.last a {
 	opacity: .5;
 }
 
+#gallery a {
+	-webkit-transition: all .2s ease-in-out;
+	transition: all .2s ease-in-out;
+}
+
 #gallery a.image > img {
 	max-height: 200px;
 }
 
 #gallery .cropped,
 #gallery .row {
-	opacity: 1;
+	opacity: 0.5;
 	-webkit-transition: opacity 500ms;
 	transition: opacity 500ms;
 }
@@ -200,6 +205,16 @@ div.crumb.last a {
 	margin: 1px;
 	background-position: center;
 	background-size: cover;
+}
+
+#gallery a.album .icon-loading,
+#gallery .image-container .icon-loading {
+	margin: auto;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
 }
 
 #gallery > h2 {

--- a/css/styles.css
+++ b/css/styles.css
@@ -146,10 +146,16 @@ div.crumb.last a {
 
 #gallery .row > a > .album-label,
 #gallery .row > a > .image-label {
-	background: rgba(0, 0, 0, 0.4);
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	transition: opacity 200ms linear;
+	opacity: 1;
+	background-image: linear-gradient(rgba(0,0,0,0) 65%,rgba(0,0,0,0.35));
 }
 
-#gallery .row > a > .image-label .title {
+#gallery .row > a > .image-label .title,
+#gallery .row > a > .album-label .title {
 	display: inline-block;
 	color: #fff;
 	text-align: center;
@@ -159,9 +165,13 @@ div.crumb.last a {
 	overflow-x: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	left: 0;
+	bottom: 10px;
+	position: absolute;
 }
 
-#gallery .row > a > .image-label .title:hover {
+#gallery .row > a > .image-label .title:hover,
+#gallery .row > a > .album-label .title:hover {
 	overflow: visible;
 	white-space: normal;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -279,12 +279,6 @@ http://www.bypeople.com/author/comatosed/*/
 	border-color: #bbb #bbb transparent #bbb;
 }
 
-#loading-indicator {
-	height: 32px;
-	width: 100%;
-	margin-bottom: 50px;
-}
-
 .icon-gallery {
 	background-image: url('../img/gallery-dark.svg');
 }

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -260,7 +260,6 @@
 			emptyContentElement.html(message);
 			emptyContentElement.removeClass('hidden');
 			$('#controls').addClass('hidden');
-			$('#loading-indicator').hide();
 		},
 
 		/**

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -360,7 +360,10 @@
 				}
 			};
 			Gallery.activeSlideShow.show(start);
-
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
+			$('.album-info-container').slideUp();
 			// Resets the last focused element
 			document.activeElement.blur();
 		},

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -7,7 +7,9 @@
 		'data-width="{{targetWidth}}" data-height="{{targetHeight}}"' +
 		'href="{{targetPath}}">' +
 		'	<div class="album-loader loading"></div>' +
-		'	<span class="album-label">{{label}}</span>' +
+		'	<span class="album-label">' +
+		'		<span class="title">{{label}}</span>' +
+		'	</span>' +
 		'	<div class="album container" style="width: {{targetWidth}}px; height: {{targetHeight}}px;" >' +
 		'	</div>' +
 		'</a>';

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -157,6 +157,9 @@
 			event.stopPropagation();
 			// show loading animation
 			this.loader.show();
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
 		},
 
 		/**

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -3,14 +3,14 @@
 	"use strict";
 
 	var TEMPLATE =
-		'<div class="item-container album-container" ' +
-		'style="width: {{targetWidth}}px; height: {{targetHeight}}px;" ' +
-		'data-width="{{targetWidth}}" data-height="{{targetHeight}}">' +
+		'<a style="width: {{targetWidth}}px; height: {{targetHeight}}px;" ' +
+		'data-width="{{targetWidth}}" data-height="{{targetHeight}}"' +
+		'href="{{targetPath}}">' +
 		'	<div class="album-loader loading"></div>' +
 		'	<span class="album-label">{{label}}</span>' +
-		'	<a class="album" href="{{targetPath}}" ' +
-		'	style="width: {{targetWidth}}px; height: {{targetHeight}}px;" ></a>' +
-		'</div>';
+		'	<div class="album container" style="width: {{targetWidth}}px; height: {{targetHeight}}px;" >' +
+		'	</div>' +
+		'</a>';
 
 	/**
 	 * Creates a new album object to store information about an album
@@ -70,7 +70,7 @@
 				this.domDef = $(albumElement);
 				this.loader = this.domDef.children('.album-loader');
 				this.loader.hide();
-				this.domDef.click(this._showLoader.bind(this));
+				this.domDef.click(this._openAlbum.bind(this));
 
 				// Define a if you don't want to set the style in the template
 				//a.width(targetHeight);
@@ -146,13 +146,14 @@
 		},
 
 		/**
-		 * Shows a loading animation
+		 * Call when the album is clicked on.
 		 *
 		 * @param event
 		 * @private
 		 */
-		_showLoader: function (event) {
+		_openAlbum: function (event) {
 			event.stopPropagation();
+			// show loading animation
 			this.loader.show();
 		},
 
@@ -268,16 +269,16 @@
 		 */
 		_fillSubAlbum: function (targetHeight) {
 			var album = this;
-			var a = this.domDef.children('a');
+			var subAlbum = this.domDef.children('.album');
 
 			if (this.images.length >= 1) {
-				this._getFourImages(this.images, targetHeight, a).fail(function (validImages) {
+				this._getFourImages(this.images, targetHeight, subAlbum).fail(function (validImages) {
 					album.images = validImages;
-					album._fillSubAlbum(targetHeight, a);
+					album._fillSubAlbum(targetHeight, subAlbum);
 				});
 			} else {
 				var imageHolder = $('<div class="cropped">');
-				a.append(imageHolder);
+				subAlbum.append(imageHolder);
 				this._showFolder(targetHeight, imageHolder);
 			}
 		},

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -3,14 +3,13 @@
 	"use strict";
 
 	var TEMPLATE =
-		'<div class="item-container image-container" ' +
-		'style="width: {{targetWidth}}px; height: {{targetHeight}}px;">' +
+		'<a style="width: {{targetWidth}}px; height: {{targetHeight}}px;" href="">' +
 		'	<div class="image-loader loading"></div>' +
 		'	<span class="image-label">' +
 		'		<span class="title">{{label}}</span>' +
 		'	</span>' +
-		'	<a class="image" href="" data-path="{{path}}"></a>' +
-		'</div>';
+		'	<div class="image container" data-path="{{path}}"></div>' +
+		'</a>';
 
 	/**
 	 * Creates a new image object to store information about a media file
@@ -119,9 +118,8 @@
 					.attr('data-height', targetHeight);
 
 				var url = this._getLink();
-				var a = this.domDef.children('a');
-				a.attr('href', url)
-					.attr('data-path', this.path);
+				var image = this.domDef.children('.image');
+				this.domDef.attr('href', url);
 
 				// This will stretch wide images to make them reach targetHeight
 				$(img).css({
@@ -129,7 +127,9 @@
 					'height': targetHeight
 				});
 				img.alt = encodeURI(this.path);
-				a.append(img);
+				image.append(img);
+
+				this.domDef.click(this._openImage.bind(this));
 			}
 		},
 
@@ -168,6 +168,17 @@
 			}
 
 			return url;
+		},
+
+		/**
+		 * Call when the image is clicked on.
+		 *
+		 * @param event
+		 * @private
+		 */
+		_openImage: function (event) {
+			event.stopPropagation();
+			// click function for future use.
 		}
 	};
 

--- a/js/galleryinfobox.js
+++ b/js/galleryinfobox.js
@@ -26,6 +26,9 @@
 		 * Shows an information box to the user
 		 */
 		showInfo: function () {
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
 			if (this.infoContentContainer.is(':visible')) {
 				this.infoContentContainer.slideUp();
 			} else {

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -13,7 +13,7 @@
 		this.items = [];
 		this.width = 4; // 4px margin to start with
 		this.requestId = requestId;
-		this.domDef = null;
+		this.domDef = $('<div/>').addClass('row');
 	};
 
 	Row.prototype = {
@@ -29,12 +29,16 @@
 			var row = this;
 			var fileNotFoundStatus = 404;
 			var def = new $.Deferred();
+			var itemDom;
 
 			var validateRowWidth = function (width) {
 				row.items.push(element);
 				row.width += width + 4; // add 4px for the margin
 				def.resolve(!row._isFull());
 			};
+
+			itemDom = element.getDom(row.targetHeight);
+			row.domDef.append(itemDom);
 
 			// No need to use getThumbnailWidth() for albums, the width is always 200
 			if (element instanceof Album) {
@@ -44,11 +48,14 @@
 				// We can't calculate the total width if we don't have the width of the thumbnail
 				element.getThumbnailWidth().then(function (width) {
 					if (element.thumbnail.status !== fileNotFoundStatus) {
+						element.resize(row.targetHeight);
 						validateRowWidth(width);
 					} else {
+						itemDom.remove();
 						def.resolve(true);
 					}
 				}, function () {
+					itemDom.remove();
 					def.resolve(true);
 				});
 			}
@@ -57,33 +64,43 @@
 		},
 
 		/**
-		 * Creates the row element in the DOM
+		 * Returns the DOM element of the row
 		 *
 		 * @returns {*}
 		 */
 		getDom: function () {
+			return this.domDef;
+		},
+
+		/**
+		 * Resizes the row once it's full
+		 */
+		fit: function () {
 			var scaleRatio = (this.width > this.targetWidth) ? this.targetWidth / this.width : 1;
-			var targetHeight = this.targetHeight * scaleRatio;
+
+			// This animates the elements when the window is resized
+			var targetHeight = 4 + (this.targetHeight * scaleRatio);
 			targetHeight = targetHeight.toFixed(3);
-			var row = $('<div/>').addClass('row');
-			/**
-			 * @param {*} row
-			 * @param {GalleryImage[]|Album[]} items
-			 * @param {number} i
-			 *
-			 * @returns {*}
-			 */
-			var addImageToDom = function (row, items, i) {
-				return items[i].getDom(targetHeight).then(function (itemDom) {
-					i++;
-					row.append(itemDom);
-					if (i < items.length) {
-						return addImageToDom(row, items, i);
-					}
-					return row;
-				});
-			};
-			return addImageToDom(row, this.items, 0);
+			this.domDef.height(targetHeight);
+			this.domDef.width(this.width * scaleRatio);
+
+			// Resizes and scales all photowall elements to make them fit within the window's width
+			this.domDef.find('.item-container').each(function () {
+				// Necessary since DOM elements are not resized when CSS transform is used
+				$(this).css('width', $(this).data('width') * scaleRatio)
+					.css('height', $(this).data('height') * scaleRatio);
+				// This scales the anchors inside the item-container divs
+				$(this).children('a').css('transform-origin', 'left top')
+					.css('-webkit-transform-origin', 'left top')
+					.css('-ms-transform-origin', 'left top')
+					.css('transform', 'scale(' + scaleRatio + ')')
+					.css('-webkit-transform', 'scale(' + scaleRatio + ')')
+					.css('-ms-transform', 'scale(' + scaleRatio + ')');
+			});
+
+			// Restore the rows to their normal opacity. This happens immediately with rows
+			// containing albums only
+			this.domDef.css('opacity', 1);
 		},
 
 		/**

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -85,12 +85,12 @@
 			this.domDef.width(this.width * scaleRatio);
 
 			// Resizes and scales all photowall elements to make them fit within the window's width
-			this.domDef.find('.item-container').each(function () {
+			this.domDef.find('a').each(function () {
 				// Necessary since DOM elements are not resized when CSS transform is used
 				$(this).css('width', $(this).data('width') * scaleRatio)
 					.css('height', $(this).data('height') * scaleRatio);
-				// This scales the anchors inside the item-container divs
-				$(this).children('a').css('transform-origin', 'left top')
+				// This scales the containers inside the anchors
+				$(this).children('.container').css('transform-origin', 'left top')
 					.css('-webkit-transform-origin', 'left top')
 					.css('-ms-transform-origin', 'left top')
 					.css('transform', 'scale(' + scaleRatio + ')')

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -141,7 +141,7 @@
 			// 2 windows worth of rows is the limit from which we need to start loading new rows.
 			// As we scroll down, it grows
 			var targetHeight = ($(window).height() * 2) + scroll;
-			var showRows = function (album) {
+			var showRows = _.throttle(function (album) {
 
 				// If we've reached the end of the album, we kill the loader
 				if (!(album.viewedItems < album.subAlbums.length + album.images.length)) {
@@ -185,7 +185,7 @@
 					// Something went wrong, so kill the loader
 					view.loadVisibleRows.loading = null;
 				});
-			};
+			}, 100);
 			if (this.element.height() < targetHeight) {
 				this.loadVisibleRows.loading = true;
 				this.loadVisibleRows.loading = showRows(album);

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -153,46 +153,41 @@
 
 				// Everything is still in sync, since no deferred calls have been placed yet
 
-				return album.getNextRow($(window).width()).then(function (row) {
+				var row = album.getRow($(window).width(), view.requestId);
+				var rowDom = row.getDom();
+				view.element.append(rowDom);
 
+				return album.fillNextRow(row).then(function () {
 					/**
 					 * At this stage, the row has a width and contains references to images based
 					 * on
 					 * information available when making the request, but this information may have
 					 * changed while we were receiving thumbnails for the row
 					 */
-
 					if (view.requestId === row.requestId) {
-						return row.getDom().then(function (dom) {
-
-							if (Gallery.currentAlbum !== path) {
-								view.loadVisibleRows.loading = null;
-								return; //throw away the row if the user has navigated away in the
-										// meantime
-							}
-							if (view.element.length === 1) {
-								Gallery.showNormal();
-							}
-
-							view.element.append(dom);
-
-							if (album.viewedItems < album.subAlbums.length + album.images.length &&
-								view.element.height() < targetHeight) {
-								return showRows(album);
-							}
-
-							// No more rows to load at the moment
+						if (Gallery.currentAlbum !== path) {
 							view.loadVisibleRows.loading = null;
-							$('#loading-indicator').hide();
-						}, function () {
-							// Something went wrong, so kill the loader
-							view.loadVisibleRows.loading = null;
-							$('#loading-indicator').hide();
-						});
+							return; //throw away the row if the user has navigated away in the
+									// meantime
+						}
+						if (view.element.length === 1) {
+							Gallery.showNormal();
+						}
+						if (album.viewedItems < album.subAlbums.length + album.images.length &&
+							view.element.height() < targetHeight) {
+							return showRows(album);
+						}
+						// No more rows to load at the moment
+						view.loadVisibleRows.loading = null;
+						$('#loading-indicator').hide();
+					} else {
+						// This is the safest way to do things
+						view.viewAlbum(Gallery.currentAlbum);
 					}
-					// This is the safest way to do things
-					view.viewAlbum(Gallery.currentAlbum);
-
+				}, function () {
+					// Something went wrong, so kill the loader
+					view.loadVisibleRows.loading = null;
+					$('#loading-indicator').hide();
 				});
 			};
 			if (this.element.height() < targetHeight) {

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -80,7 +80,6 @@
 			}
 
 			this.clear();
-			$('#loading-indicator').show();
 
 			if (albumPath !== Gallery.currentAlbum) {
 				this.loadVisibleRows.loading = false;
@@ -147,7 +146,6 @@
 				// If we've reached the end of the album, we kill the loader
 				if (!(album.viewedItems < album.subAlbums.length + album.images.length)) {
 					view.loadVisibleRows.loading = null;
-					$('#loading-indicator').hide();
 					return;
 				}
 
@@ -179,7 +177,6 @@
 						}
 						// No more rows to load at the moment
 						view.loadVisibleRows.loading = null;
-						$('#loading-indicator').hide();
 					} else {
 						// This is the safest way to do things
 						view.viewAlbum(Gallery.currentAlbum);
@@ -187,7 +184,6 @@
 				}, function () {
 					// Something went wrong, so kill the loader
 					view.loadVisibleRows.loading = null;
-					$('#loading-indicator').hide();
 				});
 			};
 			if (this.element.height() < targetHeight) {
@@ -198,7 +194,6 @@
 		},
 
 		hideButtons: function () {
-			$('#loading-indicator').hide();
 			$('#album-info-button').hide();
 			$('#share-button').hide();
 			$('#sort-name-button').hide();

--- a/l10n/cs_CZ.js
+++ b/l10n/cs_CZ.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "skupina",
     "remote" : "vzdálený",
     "Resharing is not allowed" : "Sdílení již sdílené položky není povoleno",
+    "Error while retrieving shares" : "Chyba při otevírání sdílení",
     "Unshare" : "Zrušit sdílení",
     "notify by email" : "upozornit emailem",
     "can share" : "může sdílet",

--- a/l10n/cs_CZ.json
+++ b/l10n/cs_CZ.json
@@ -55,6 +55,7 @@
     "group" : "skupina",
     "remote" : "vzdálený",
     "Resharing is not allowed" : "Sdílení již sdílené položky není povoleno",
+    "Error while retrieving shares" : "Chyba při otevírání sdílení",
     "Unshare" : "Zrušit sdílení",
     "notify by email" : "upozornit emailem",
     "can share" : "může sdílet",

--- a/l10n/fi_FI.js
+++ b/l10n/fi_FI.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "ryhmä",
     "remote" : "etä",
     "Resharing is not allowed" : "Jakaminen uudelleen ei ole salittu",
+    "Error while retrieving shares" : "Virhe jakoja noutaessa",
     "Unshare" : "Peru jakaminen",
     "notify by email" : "ilmoita sähköpostitse",
     "can share" : "jaa",

--- a/l10n/fi_FI.json
+++ b/l10n/fi_FI.json
@@ -55,6 +55,7 @@
     "group" : "ryhmä",
     "remote" : "etä",
     "Resharing is not allowed" : "Jakaminen uudelleen ei ole salittu",
+    "Error while retrieving shares" : "Virhe jakoja noutaessa",
     "Unshare" : "Peru jakaminen",
     "notify by email" : "ilmoita sähköpostitse",
     "can share" : "jaa",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "groupe",
     "remote" : "distant",
     "Resharing is not allowed" : "Le repartage n'est pas autorisé",
+    "Error while retrieving shares" : "Erreur lors de la récupération des partages",
     "Unshare" : "Ne plus partager",
     "notify by email" : "notifier par courriel",
     "can share" : "peut partager",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -55,6 +55,7 @@
     "group" : "groupe",
     "remote" : "distant",
     "Resharing is not allowed" : "Le repartage n'est pas autorisé",
+    "Error while retrieving shares" : "Erreur lors de la récupération des partages",
     "Unshare" : "Ne plus partager",
     "notify by email" : "notifier par courriel",
     "can share" : "peut partager",

--- a/l10n/he.js
+++ b/l10n/he.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "קבוצה",
     "remote" : "נשלט מרחוק",
     "Resharing is not allowed" : "אסור לעשות שיתוף מחדש",
+    "Error while retrieving shares" : "שגיאה במהלך שליפת שיתופים",
     "Unshare" : "הסר שיתוף",
     "notify by email" : "קבלת הודעה בדואר אלקטרוני",
     "can share" : "ניתן לשתף",

--- a/l10n/he.json
+++ b/l10n/he.json
@@ -55,6 +55,7 @@
     "group" : "קבוצה",
     "remote" : "נשלט מרחוק",
     "Resharing is not allowed" : "אסור לעשות שיתוף מחדש",
+    "Error while retrieving shares" : "שגיאה במהלך שליפת שיתופים",
     "Unshare" : "הסר שיתוף",
     "notify by email" : "קבלת הודעה בדואר אלקטרוני",
     "can share" : "ניתן לשתף",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "gruppo",
     "remote" : "remota",
     "Resharing is not allowed" : "La ri-condivisione non è consentita",
+    "Error while retrieving shares" : "Errore durante il recupero delle condivisioni",
     "Unshare" : "Rimuovi condivisione",
     "notify by email" : "notifica tramite email",
     "can share" : "può condividere",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -55,6 +55,7 @@
     "group" : "gruppo",
     "remote" : "remota",
     "Resharing is not allowed" : "La ri-condivisione non è consentita",
+    "Error while retrieving shares" : "Errore durante il recupero delle condivisioni",
     "Unshare" : "Rimuovi condivisione",
     "notify by email" : "notifica tramite email",
     "can share" : "può condividere",

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "grupo",
     "remote" : "remoto",
     "Resharing is not allowed" : "Não é permitido re-compartilhar",
+    "Error while retrieving shares" : "Erro ao recuperar compartilhamentos",
     "Unshare" : "Descompartilhar",
     "notify by email" : "notificar por e-mail",
     "can share" : "pode compartilhar",

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -55,6 +55,7 @@
     "group" : "grupo",
     "remote" : "remoto",
     "Resharing is not allowed" : "Não é permitido re-compartilhar",
+    "Error while retrieving shares" : "Erro ao recuperar compartilhamentos",
     "Unshare" : "Descompartilhar",
     "notify by email" : "notificar por e-mail",
     "can share" : "pode compartilhar",

--- a/l10n/sq.js
+++ b/l10n/sq.js
@@ -57,6 +57,7 @@ OC.L10N.register(
     "group" : "grup",
     "remote" : "i largët",
     "Resharing is not allowed" : "Nuk lejohen rindarjet",
+    "Error while retrieving shares" : "Gabim teksa merreshin ndarjet",
     "Unshare" : "Hiqja ndarjen",
     "notify by email" : "njoftoje me email",
     "can share" : "mund të ndajë",

--- a/l10n/sq.json
+++ b/l10n/sq.json
@@ -55,6 +55,7 @@
     "group" : "grup",
     "remote" : "i largët",
     "Resharing is not allowed" : "Nuk lejohen rindarjet",
+    "Error while retrieving shares" : "Gabim teksa merreshin ndarjet",
     "Unshare" : "Hiqja ndarjen",
     "notify by email" : "njoftoje me email",
     "can share" : "mund të ndajë",

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -99,5 +99,4 @@ style(
 </div>
 <div id="gallery" class="hascontrols"></div>
 <div id="emptycontent" class="hidden"></div>
-<div id="loading-indicator" class="loading"></div>
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="yes"/>

--- a/templates/public.php
+++ b/templates/public.php
@@ -151,7 +151,6 @@ style(
 				 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
 			</div>
 			<div id="emptycontent" class="hidden"></div>
-			<div id="loading-indicator" class="loading"></div>
 		</div>
 	</div>
 	<footer>

--- a/templates/public.php
+++ b/templates/public.php
@@ -157,4 +157,3 @@ style(
 		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>
 	</footer>
 </div>
-


### PR DESCRIPTION
Fixes: #545 

Licence: AGPL
### Description

Initial commit had a regression. Has been fixed by adding `hideDropDown` button in the gallery.js file
### Features

Should fix the errors related to share dialog not closing.
### Test Plan

First click on the share button, then
- [ ] Click on any album.
- [ ] Click on any image.
- [ ] Click on infobutton.

Then,
- [ ] Similarly do the same on public side after sharing a file/folder.

Then,
- [ ] Similarly do the  same on the files app side too. 

Should not give any errors and share dialog should close.
### Tested on
- [X] Ubuntu 14.04/Chrome
### Reviewers

@oparoz @imjalpreet  @tahaalibra @mbtamuli
