### PR TITLE
Close the share dialogue when performing another action, fixes #545

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -360,8 +360,7 @@
 				}
 			};
 			Gallery.activeSlideShow.show(start);
-			if(!_.isUndefined(Gallery.Share))
-			{
+			if(!_.isUndefined(Gallery.Share)){
 				Gallery.Share.hideDropDown();
 			}
 			$('.album-info-container').slideUp();

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -360,7 +360,11 @@
 				}
 			};
 			Gallery.activeSlideShow.show(start);
-
+			if(!_.isUndefined(Gallery.Share))
+			{
+				Gallery.Share.hideDropDown();
+			}
+			$('.album-info-container').slideUp();
 			// Resets the last focused element
 			document.activeElement.blur();
 		},

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -157,8 +157,7 @@
 			event.stopPropagation();
 			// show loading animation
 			this.loader.show();
-			if(!_.isUndefined(Gallery.Share))
-			{
+			if(!_.isUndefined(Gallery.Share)){
 				Gallery.Share.hideDropDown();
 			}
 		},

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -157,6 +157,10 @@
 			event.stopPropagation();
 			// show loading animation
 			this.loader.show();
+			if(!_.isUndefined(Gallery.Share))
+			{
+				Gallery.Share.hideDropDown();
+			}
 		},
 
 		/**

--- a/js/galleryinfobox.js
+++ b/js/galleryinfobox.js
@@ -26,6 +26,10 @@
 		 * Shows an information box to the user
 		 */
 		showInfo: function () {
+			if(!_.isUndefined(Gallery.Share))
+			{
+				Gallery.Share.hideDropDown();
+			}
 			if (this.infoContentContainer.is(':visible')) {
 				this.infoContentContainer.slideUp();
 			} else {

--- a/js/galleryinfobox.js
+++ b/js/galleryinfobox.js
@@ -26,8 +26,7 @@
 		 * Shows an information box to the user
 		 */
 		showInfo: function () {
-			if(!_.isUndefined(Gallery.Share))
-			{
+			if(!_.isUndefined(Gallery.Share)){
 				Gallery.Share.hideDropDown();
 			}
 			if (this.infoContentContainer.is(':visible')) {


### PR DESCRIPTION
Fixes: #545 

Licence: AGPL
### Description

Initial commit had a regression. Has been fixed by adding `hideDropDown` button in the gallery.js file
### Features

Should fix the errors related to share dialog not closing.
### Test Plan

First click on the share button, then
- [ ] Click on any album.
- [ ] Click on any image.
- [ ] Click on infobutton.

Then,
- [ ] Similarly do the same on public side after sharing a file/folder.

Then,
- [ ] Similarly do the  same on the files app side too. 

Should not give any errors and share dialog should close.
### Tested on
- [X] Ubuntu 14.04/Chrome
### Reviewers

@oparoz @imjalpreet  @tahaalibra @mbtamuli
