### PR TITLE
Fix element selector in acceptance tests

### DIFF
--- a/tests/_support/Page/Acceptance/Login.php
+++ b/tests/_support/Page/Acceptance/Login.php
@@ -57,7 +57,7 @@ class Login {
 	public function confirmLogin() {
 		$I = $this->acceptanceTester;
 
-		$I->seeElement(FilesPage::$contentDiv);
 		$I->seeCurrentUrlEquals(FilesPage::$URL);
+		$I->seeElement(['css' => FilesPage::$contentDiv]);
 	}
 }

--- a/tests/acceptance/LoginCept.php
+++ b/tests/acceptance/LoginCept.php
@@ -17,4 +17,4 @@ $I->am('A standard user');
 $I->wantTo('ensure that I can see the login page');
 
 $I->amOnPage(LoginPage::$URL);
-$I->seeElement(LoginPage::$loginButton);
+$I->seeElement(['css' => LoginPage::$loginButton]);

--- a/tests/acceptance/SignInAsUserCept.php
+++ b/tests/acceptance/SignInAsUserCept.php
@@ -26,4 +26,4 @@ $loginPage->confirmLogin();
 $I->click('.menutoggle');
 $I->click('Gallery', '#navigation');
 $I->seeCurrentUrlEquals(GalleryPage::$URL);
-$I->seeElement(GalleryPage::$contentDiv);
+$I->seeElement(['css' => GalleryPage::$contentDiv]);


### PR DESCRIPTION
By not specifying exactly what we need, we let Codeception use a fuzzy engine to find a best match and it sometimes fails to find the element we're expecting to see on screen.
