### PR TITLE
Don't add our encrypted Github token to git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ before_install:
   #- phantomjs --webdriver=4444 --ignore-ssl-errors=true --webdriver-loglevel=DEBUG &
 
   # Get rid of Github limits
-  - git config --global github.accesstoken $GH_TOKEN
+  # Only enable temporarily when making large package changes with composer
+  #- git config --global github.accesstoken $GH_TOKEN
 
   # Make modifications to the environment to allow us to retrieve core dumps
   # When debugging, make sure you enable sudo by commenting out the first line of this file


### PR DESCRIPTION
Encrypted variables are not available to forks and some people make MIT contributions without ever becoming ownCloud members on Github.
Instead of adding a read-only token or forcing people to create branches in the ownCloud domain, we simply don't use a token any more because the limit is rarely reached due to our use of the Travis caching mechanism.
