### PR TITLE
Close the share dialogue when performing another action, fixes #545

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -318,7 +318,10 @@
 				}
 			};
 			Gallery.activeSlideShow.show(start);
-
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
+			$('.album-info-container').slideUp();
 			// Resets the last focused element
 			document.activeElement.blur();
 		},

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -211,7 +211,9 @@
 			event.stopPropagation();
 			// show loading animation
 			this.loader.show();
-			Gallery.Share.hideDropDown();
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
 		},
 
 		/**

--- a/js/galleryinfobox.js
+++ b/js/galleryinfobox.js
@@ -26,7 +26,9 @@
 		 * Shows an information box to the user
 		 */
 		showInfo: function () {
-			Gallery.Share.hideDropDown();
+			if(!_.isUndefined(Gallery.Share)){
+				Gallery.Share.hideDropDown();
+			}
 			if (this.infoContentContainer.is(':visible')) {
 				this.infoContentContainer.slideUp();
 			} else {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -92,8 +92,6 @@
 		 * @returns {*}
 		 */
 		show: function (index) {
-			Gallery.Share.hideDropDown();
-			$('.album-info-container').slideUp();
 			this.hideErrorNotification();
 			this.active = true;
 			this.container.show();


### PR DESCRIPTION
Fixes: #545 

Licence: AGPL
### Description

Initial commit had a regression. Has been fixed by adding `hideDropDown` button in the gallery.js file
### Features

Should fix the errors related to share dialog not closing.
### Test Plan

First click on the share button, then
- [ ] Click on any album.
- [ ] Click on any image.
- [ ] Click on infobutton.

Then,
- [ ] Similarly do the same on public side after sharing a file/folder.

Then,
- [ ] Similarly do the  same on the files app side too. 

Should not give any errors and share dialog should close.
### Tested on
- [X] Ubuntu 14.04/Chrome
### Reviewers

@oparoz @imjalpreet  @tahaalibra @mbtamuli
