### PR TITLE
Fix empty page message position

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -82,7 +82,6 @@ div.crumb.last a {
 	overflow: hidden;
 	text-align: justify;
 	top: 45px;
-	padding-bottom: 100px;
 	margin-bottom: 45px;
 	margin-top: 0;
 }


### PR DESCRIPTION
Fixes: #569 

Licence: MIT
### Description

The padding in `#gallery.hascontrols` pushed the empty message to the bottom.
### Screenshots or screencasts

<img width="717" alt="screen shot 2016-03-21 at 3 14 37 pm" src="https://cloud.githubusercontent.com/assets/2311316/13914956/b23aea84-ef77-11e5-8dae-fc2fb459c568.png">
## Tests
### Tested on
- [x] Safari (OS X)
- [x] Chrome (OS X)
- [x] Firefox (OS X)
### Check list
- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

 @oparoz, @raghunayyar and @jancborchardt
