### PR TITLE
Don't ask to load new rows until the last operation is completed

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -49,8 +49,7 @@ $(document).ready(function () {
 
 		// This block loads new rows
 		$('html, #content-wrapper').scroll(function () {
-			Gallery.view.loadVisibleRows(Gallery.albumMap[Gallery.currentAlbum],
-				Gallery.currentAlbum);
+			Gallery.view.loadVisibleRows(Gallery.albumMap[Gallery.currentAlbum]);
 		});
 
 

--- a/js/galleryalbum.js
+++ b/js/galleryalbum.js
@@ -54,6 +54,7 @@
 	};
 
 	Album.prototype = {
+		requestId: null,
 		droppableOptions: {
 			accept: '#gallery > .row > a',
 			activeClass: 'album-droppable',
@@ -86,12 +87,11 @@
 		 * Returns a new album row
 		 *
 		 * @param {number} width
-		 * @param requestId
 		 *
 		 * @returns {Gallery.Row}
 		 */
-		getRow: function (width, requestId) {
-			return new Gallery.Row(width, requestId);
+		getRow: function (width) {
+			return new Gallery.Row(width);
 		},
 
 		/**

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -5,14 +5,12 @@
 	 * Creates a row
 	 *
 	 * @param {number} targetWidth
-	 * @param {number} requestId
 	 * @constructor
 	 */
-	var Row = function (targetWidth, requestId) {
+	var Row = function (targetWidth) {
 		this.targetWidth = targetWidth;
 		this.items = [];
 		this.width = 4; // 4px margin to start with
-		this.requestId = requestId;
 		this.domDef = $('<div/>').addClass('row');
 	};
 

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -29,6 +29,8 @@
 		 * Removes all thumbnails from the view
 		 */
 		clear: function () {
+			this.loadVisibleRows.processing = false;
+			this.loadVisibleRows.loading = null;
 			// We want to keep all the events
 			this.element.children().detach();
 			this.showLoading();
@@ -82,7 +84,6 @@
 			this.clear();
 
 			if (Gallery.albumMap[albumPath].etag !== Gallery.currentEtag) {
-				this.loadVisibleRows.loading = false;
 				Gallery.currentAlbum = albumPath;
 				Gallery.currentEtag = Gallery.albumMap[albumPath].etag;
 				this._setupButtons(albumPath);
@@ -98,7 +99,7 @@
 			// Loading rows without blocking the execution of the rest of the script
 			setTimeout(function () {
 				this.loadVisibleRows.activeIndex = 0;
-				this.loadVisibleRows(Gallery.albumMap[Gallery.currentAlbum], Gallery.currentAlbum);
+				this.loadVisibleRows(Gallery.albumMap[Gallery.currentAlbum]);
 			}.bind(this), 0);
 		},
 
@@ -120,75 +121,65 @@
 		/**
 		 * Loads and displays gallery rows on screen
 		 *
-		 * @param {Album} album
-		 * @param {string} path
+		 * view.loadVisibleRows.loading holds the Promise of a row
 		 *
-		 * @returns {boolean|null|*}
+		 * @param {Album} album
 		 */
-		loadVisibleRows: function (album, path) {
+		loadVisibleRows: function (album) {
 			var view = this;
-			// If the row is still loading (state() = 'pending'), let it load
-			if (this.loadVisibleRows.loading &&
-				this.loadVisibleRows.loading.state() !== 'resolved') {
-				return this.loadVisibleRows.loading;
+			// Wait for the previous request to be completed
+			if (this.loadVisibleRows.processing) {
+				return;
 			}
 
 			/**
-			 * At this stage, there is no loading taking place (loading = false|null), so we can
-			 * look for new rows
+			 * At this stage, there is no loading taking place, so we can look for new rows
 			 */
 
 			var scroll = $('#content-wrapper').scrollTop() + $(window).scrollTop();
 			// 2 windows worth of rows is the limit from which we need to start loading new rows.
 			// As we scroll down, it grows
 			var targetHeight = ($(window).height() * 2) + scroll;
+			// We throttle rows in order to try and not generate too many CSS resizing events at
+			// the same time
 			var showRows = _.throttle(function (album) {
 
 				// If we've reached the end of the album, we kill the loader
 				if (!(album.viewedItems < album.subAlbums.length + album.images.length)) {
+					view.loadVisibleRows.processing = false;
 					view.loadVisibleRows.loading = null;
 					return;
 				}
 
-				// Everything is still in sync, since no deferred calls have been placed yet
+				// Prevents creating rows which are no longer required. I.e when changing album
+				if (view.requestId !== album.requestId) {
+					return;
+				}
 
-				var row = album.getRow($(window).width(), view.requestId);
+				// We can now safely create a new row
+				var row = album.getRow($(window).width());
 				var rowDom = row.getDom();
 				view.element.append(rowDom);
 
 				return album.fillNextRow(row).then(function () {
-					/**
-					 * At this stage, the row has a width and contains references to images based
-					 * on
-					 * information available when making the request, but this information may have
-					 * changed while we were receiving thumbnails for the row
-					 */
-					if (view.requestId === row.requestId) {
-						if (Gallery.currentAlbum !== path) {
-							view.loadVisibleRows.loading = null;
-							return; //throw away the row if the user has navigated away in the
-									// meantime
-						}
-						if (album.viewedItems < album.subAlbums.length + album.images.length &&
-							view.element.height() < targetHeight) {
-							return showRows(album);
-						}
-						// No more rows to load at the moment
-						view.loadVisibleRows.loading = null;
-					} else {
-						// This is the safest way to do things
-						view.viewAlbum(Gallery.currentAlbum);
+					if (album.viewedItems < album.subAlbums.length + album.images.length &&
+						view.element.height() < targetHeight) {
+						return showRows(album);
 					}
+					// No more rows to load at the moment
+					view.loadVisibleRows.processing = false;
+					view.loadVisibleRows.loading = null;
 				}, function () {
 					// Something went wrong, so kill the loader
+					view.loadVisibleRows.processing = false;
 					view.loadVisibleRows.loading = null;
 				});
 			}, 100);
 			if (this.element.height() < targetHeight) {
 				this._showNormal();
-				this.loadVisibleRows.loading = true;
+				this.loadVisibleRows.processing = true;
+				album.requestId = view.requestId;
 				this.loadVisibleRows.loading = showRows(album);
-				return this.loadVisibleRows.loading;
 			}
 		},
 


### PR DESCRIPTION
Fixes: #614 
### Description

If you scroll down while the rows are rendering, some images can end up on the wrong rows and the photowall won't be seamless
Similarly, if you scroll down a bit and then decide to upload an image, the rendering starts and is disrupted after a few rows.

My solution is to change the way we detect that an operation is still ongoing.
### Caveats

I haven't noticed any difference in rendering speed on my setup, but let me know if something doesn't feel right.
## Tests
### Test plan

<!--
Add each test which should be performed and give a general description of the context
You can also link to one or more entries from the "Acceptance tests" section in the wiki
-->

The tests in #614 will show you what happens without this fix.
- [x] #614 test1
- [x] #614 test2
- [x] #614 test3 
- [x] Move images out of the current album
- [x] Go inside an album and come back very quickly
- [x] Resize the width or height of an album (There is still another bug hidden in there)

Basically, abuse Gallery's photowall and see if it breaks.
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
### Todo
- [x] Fix the case when users resize the window after having scrolled down
### Check list
- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@jancborchardt @jospoortvliet @setnes @demattin @arkascha @elpraga @sualko @bugsbane @mmattel
@manishbisht @tahaalibra @viraj96 @imjalpreet @mbtamuli @rahulgoyal030 @shubhrajodiya @harshjv @kartik69 @senorsen
