### PR TITLE
Add spinner before loading files

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -41,8 +41,6 @@ body {
 }
 
 #save-button-confirm:disabled, #save-button-confirm:disabled:hover, #save-button-confirm:disabled:focus {
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-    filter: alpha(opacity=20);
     opacity: .2;
     cursor: default;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -330,3 +330,29 @@ http://www.bypeople.com/author/comatosed/*/
 .icon-gallery {
 	background-image: url('../img/gallery-dark.svg');
 }
+
+.mask {
+	z-index: 50;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: #fff;
+	background-repeat: no-repeat no-repeat;
+	background-position: 50%;
+	opacity: 0.5;
+	transition: opacity 100ms;
+	-moz-transition: opacity 100ms;
+	-o-transition: opacity 100ms;
+	-ms-transition: opacity 100ms;
+	-webkit-transition: opacity 100ms;
+}
+
+.mask.transparent {
+	opacity: 0;
+}
+
+.icon-loading-dark.small {
+	background-size: 16px;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -87,6 +87,7 @@ $(document).ready(function () {
  */
 window.onhashchange = function () {
 	"use strict";
+	Gallery.view.dimControls();
 	var currentLocation = window.location.href.split('#')[1] || '';
 	// The hash location is ALWAYS encoded, despite what the browser shows
 	var path = decodeURIComponent(currentLocation);

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -109,6 +109,13 @@
 		},
 
 		/**
+		 * Shows the dark spinner on the crumb
+		 */
+		showLoader: function () {
+			$(this).children('a').addClass("icon-loading-dark small");
+		},
+
+		/**
 		 * Builds the breadcrumbs array
 		 *
 		 * @private
@@ -236,6 +243,7 @@
 			// We go through the array in reverse order
 			var crumbsElement = crumbs.get().reverse();
 			$(crumbsElement).each(function () {
+				$(this).click(self.showLoader);
 				if ($(this).hasClass('home')) {
 					$(this).show();
 					return;

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -12,7 +12,7 @@
 		appName: 'gallery',
 		token: undefined,
 		activeSlideShow: null,
-		buttonsWidth: 350,
+		buttonsWidth: 600,
 		browserToolbarHeight: 150,
 		filesClient: null,
 

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -169,9 +169,6 @@
 							return; //throw away the row if the user has navigated away in the
 									// meantime
 						}
-						if (view.element.length === 1) {
-							view._showNormal();
-						}
 						if (album.viewedItems < album.subAlbums.length + album.images.length &&
 							view.element.height() < targetHeight) {
 							return showRows(album);
@@ -188,6 +185,7 @@
 				});
 			}, 100);
 			if (this.element.height() < targetHeight) {
+				this._showNormal();
 				this.loadVisibleRows.loading = true;
 				this.loadVisibleRows.loading = showRows(album);
 				return this.loadVisibleRows.loading;
@@ -204,7 +202,9 @@
 			var message = '<div class="icon-gallery"></div>';
 			var uploadAllowed = true;
 
-			this.clear();
+			this.element.children().detach();
+			$('#content').removeClass('icon-loading');
+			this.controlsElement.find('.mask').remove();
 
 			if (!_.isUndefined(errorMessage) && errorMessage !== null) {
 				message += '<h2>' + t('gallery',
@@ -227,7 +227,6 @@
 			this.emptyContentElement.html(message);
 			this.emptyContentElement.removeClass('hidden');
 
-			//Gallery.view.showEmptyFolder();
 			this._hideButtons(uploadAllowed);
 			Gallery.currentAlbum = albumPath;
 			var availableWidth = $(window).width() - Gallery.buttonsWidth;
@@ -236,11 +235,27 @@
 		},
 
 		/**
+		 * Dims the controls bar when retrieving new content. Matches the effect in Files
+		 */
+		dimControls: function () {
+			// Use the existing mask if its already there
+			var $mask = this.controlsElement.find('.mask');
+			if ($mask.exists()) {
+				return;
+			}
+			$mask = $('<div class="mask transparent"></div>');
+			this.controlsElement.append($mask);
+			$mask.removeClass('transparent');
+		},
+
+		/**
 		 * Shows the infamous loading spinner
 		 */
 		showLoading: function () {
 			this.emptyContentElement.addClass('hidden');
 			this.controlsElement.removeClass('hidden');
+			$('#content').addClass('icon-loading');
+			this.dimControls();
 		},
 
 		/**
@@ -249,6 +264,8 @@
 		_showNormal: function () {
 			this.emptyContentElement.addClass('hidden');
 			this.controlsElement.removeClass('hidden');
+			$('#content').removeClass('icon-loading');
+			this.controlsElement.find('.mask').remove();
 		},
 
 		/**


### PR DESCRIPTION
Fixes: #598 #623 
### Description

This just improves the overall UX by adding more feedback for those times where the user has to wait for the backend to send information back, which can take a while on networked storage.
## Tests
### Test plan

<!--
Add each test which should be performed and give a general description of the context
You can also link to one or more entries from the "Acceptance tests" section in the wiki
-->
- Move up a folder using the breadcrumb
- Resize the width of the window

See the listed issues for more information
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
### Check list
- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
