### PR TITLE
Fix svg rendering

### DIFF
--- a/js/galleryconfig.js
+++ b/js/galleryconfig.js
@@ -132,7 +132,8 @@
 		 */
 		_worksInCurrentBrowser: function (feature, validationRule) {
 			var isAcceptable = true;
-			if (feature === validationRule && Gallery.ieVersion !== false) {
+			if (feature === validationRule &&
+				(Gallery.ieVersion !== false && Gallery.ieVersion !== 'edge')) {
 				isAcceptable = false;
 			}
 

--- a/js/galleryimage.js
+++ b/js/galleryimage.js
@@ -73,12 +73,18 @@
 		 *
 		 * @returns {number}
 		 */
-		getThumbnailWidth: function () {
+		getThumbnailWidth: function (targetHeight) {
+			var image = this;
 			// img is a Thumbnail.image
 			return this.getThumbnail(false).then(function (img) {
 				var width = 0;
 				if (img) {
-					width = img.originalWidth;
+					// In Firefox, you don't get the size of a SVG before it's added to the DOM
+					image.domDef.children('.image').append(img);
+					if (image.mimeType === 'image/svg+xml') {
+						image.thumbnail.ratio = img.width / img.height;
+					}
+					width = Math.round(targetHeight * image.thumbnail.ratio);
 				}
 
 				return width;
@@ -113,20 +119,18 @@
 		/**
 		 * Resizes the image once it has been loaded
 		 *
-		 * @param targetHeight
+		 * @param {Number} targetHeight
+		 * @param {Number} newWidth
 		 */
-		resize: function (targetHeight) {
+		resize: function (targetHeight, newWidth) {
 			if (this.spinner !== null) {
 				var img = this.thumbnail.image;
 				this.spinner.remove();
 				this.spinner = null;
-
-				var newWidth = Math.round(targetHeight * this.thumbnail.ratio);
 				this.domDef.attr('data-width', newWidth)
 					.attr('data-height', targetHeight);
 
 				var url = this._getLink();
-				var image = this.domDef.children('.image');
 				this.domDef.attr('href', url);
 
 				// This will stretch wide images to make them reach targetHeight
@@ -135,7 +139,6 @@
 					'height': targetHeight
 				});
 				img.alt = encodeURI(this.path);
-				image.append(img);
 
 				this.domDef.click(this._openImage.bind(this));
 			}

--- a/js/galleryrow.js
+++ b/js/galleryrow.js
@@ -80,15 +80,14 @@
 			row.domDef.append(itemDom);
 			itemDom.draggable(this.draggableOptions);
 
-			// No need to use getThumbnailWidth() for albums, the width is always 200
+			// The width of an album is always the same as its height
 			if (element instanceof Album) {
-				var width = row.targetHeight;
-				validateRowWidth(width);
+				validateRowWidth(row.targetHeight);
 			} else {
 				// We can't calculate the total width if we don't have the width of the thumbnail
-				element.getThumbnailWidth().then(function (width) {
+				element.getThumbnailWidth(row.targetHeight).then(function (width) {
 					if (element.thumbnail.status !== fileNotFoundStatus) {
-						element.resize(row.targetHeight);
+						element.resize(row.targetHeight, width);
 						validateRowWidth(width);
 					} else {
 						itemDom.remove();

--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -19,7 +19,7 @@ window.Gallery = window.Gallery || {};
 		/**
 		 * Detects if the browser is a recent or an old version of Internet Explorer
 		 *
-		 * @returns {string|bool}
+		 * @returns {string|boolean}
 		 */
 		getIeVersion: function () {
 			// Blocking IE8
@@ -27,9 +27,10 @@ window.Gallery = window.Gallery || {};
 				return 'unsupportedIe';
 			} else if (navigator.userAgent.indexOf("MSIE") > 0) {
 				return 'oldIe';
-			} else if ((!!navigator.userAgent.match(/Trident.*rv[ :]*11\./)) ||
-				(navigator.userAgent.indexOf("Edge/") > 0)) {
+			} else if (!!navigator.userAgent.match(/Trident.*rv[ :]*11\./)) {
 				return 'modernIe';
+			} else if (navigator.userAgent.indexOf("Edge/") > 0) {
+				return 'edge';
 			}
 
 			return false;

--- a/js/slideshowzoomablepreview.js
+++ b/js/slideshowzoomablepreview.js
@@ -52,10 +52,10 @@
 			var maxZoom = this.maxZoom;
 			var imgWidth = image.naturalWidth / window.devicePixelRatio;
 			var imgHeight = image.naturalHeight / window.devicePixelRatio;
-			// Disable zooming in IE when we can't get the image's size (SVG)
-			if (imgWidth === 0) {
-				$(image).attr('width', '100%')
-					.attr('height', '100%');
+			// Set arbitrary image dimension when we have a SVG
+			if (imgWidth === 0 && mimeType === 'image/svg+xml') {
+				imgWidth = 2048;
+				imgHeight = 2048;
 			}
 
 			if (imgWidth < this.smallImageDimension &&


### PR DESCRIPTION
Fixes: #615 

Licence: MIT or AGPL
### Description

Firefox doesn't report a SVGs width until AFTER it's been added to the DOM, unlike Chrome.
So I've modified the part where we return the width of a thumbnail so that it's added to the DOM before retrieving the width.
For the slideshow, I just set the dimensions to the standard dimensions found in the config file. It has no impact on performance since SVGs are mostly made of vectors.

While I was at it, I also enabled optional SVG rendering for Edge since it does work pretty well, despite all the errors spit out in the browser log.
## Tests
### Test plan

<!--
Add each test which should be performed and give a general description of the context
You can also link to one or more entries from the "Acceptance tests" section in the wiki
-->
- [x] #615 Test1
- [x] #615 Test2
### Tested on
- [x] Windows/Firefox
- [x] Windows/Chrome
- [x] Windows/IE11
- [x] Windows/Edge
### Check list
- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
### Reviewers

<!--
Please list below the Github handles of people suceptible to review this PR
-->

@kartik69
