### PR TITLE
The ending slash is optional

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -62,7 +62,7 @@ Util::addTranslations('gallery');
 $request = $c->query('Request');
 if (isset($request->server['REQUEST_URI'])) {
 	$url = $request->server['REQUEST_URI'];
-	if (preg_match('%/apps/files(_sharing)?/%', $url)
+	if (preg_match('%/apps/files(_sharing/)?%', $url)
 		|| preg_match('%^((?!/apps/).)*/s/\b(.*)\b(?<!/authenticate)$%', $url)
 	) {
 		// @codeCoverageIgnoreStart


### PR DESCRIPTION
Fixes regression in #620.

URLs in files apps can end with or without a `/` 

@rullzer @PVince81
