### PR TITLE
fix order of Gallery app in app navigation

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -34,7 +34,7 @@ $c->query('OCP\INavigationManager')
 
 			  // Sorting weight for the navigation. The higher the number, the higher
 			  // will it be listed in the navigation
-			  'order' => 3,
+			  'order' => 2,
 
 			  // The route that will be shown on startup when called from within ownCloud
 			  // Public links are using another route, see appinfo/routes.php


### PR DESCRIPTION
The idea is to have the sorting start with: Files, Activity, Gallery etc.

Please review @owncloud/designers @oparoz
