### PR TITLE
Create .nomedia file from the album itself

### DIFF
--- a/js/newfilemenuplugins.js
+++ b/js/newfilemenuplugins.js
@@ -1,0 +1,19 @@
+var galleryMenuHideAlbum = {
+	attach: function (menu) {
+		menu.addMenuEntry({
+			'id': 'hideAlbum',
+			'displayName': t('gallery', 'Hide Album'),
+			'iconClass': 'icon-close',
+			'actionHandler': function () {
+				FileList.createFile('.nomedia')
+					.then(function() {
+						window.location.reload();
+					})
+					.fail(function() {
+						OC.Notification.showTemporary(t('gallery', 'Could not hide album'));
+					});
+			}
+		});
+	}
+};
+OC.Plugins.register('Gallery.NewFileMenu', galleryMenuHideAlbum);

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -31,7 +31,8 @@ script(
 		'slideshowcontrols',
 		'slideshowzoomablepreview',
 		'upload-helper',
-		'vendor/owncloud/newfilemenu'
+		'vendor/owncloud/newfilemenu',
+		'newfilemenuplugins'
 	]
 );
 script(


### PR DESCRIPTION
Licence: MIT

Adapted owncloud/core@d3861685045a006b47c68185223be21a6233802e to make work on  #547 easier.
### Description

This pull request makes it possible, to create a .nomedia file from the album itself via the [+] button. Furthermore it adapts owncloud/core@d3861685045a006b47c68185223be21a6233802e, so that there is a [standardized way](https://doc.owncloud.org/server/9.0/developer_manual/app/js.html#extending-the-new-menu-in-the-files-app) to extend the [+]-menu.
### Features
- Possibility to extend the [+] buttons menu
- Creation of a .nomedia file from the album itself
## Tests
### Test plan
- [x] "Hide Album" Submenu is displayed
- [x] Clicking Hide-Album creates a .nomedia file
- [x] Gallery will not show up the album anymore
### Tested on
- [x] Linux/Firefox
- [x] Android 5.1/Chrome
### TODO
- [x] Implement extending [+] button menu
- [x] Document extending
- [x] Implement creation of .nomedia file
- [x] Implement what follows after hiding an album and you are "inside"
- [x] Test
### Check list
- [x] Code is properly documented
- [X] Code is properly formatted
- [X] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

This is my first pull request, so if you have any advice for me please feel welcome.
