### PR TITLE
remove the iframe transport reference which no longer exists in owncl…

### DIFF
--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -40,7 +40,6 @@ script(
 		'upload',
 		'file-upload',
 		'jquery.fileupload',
-		'jquery.iframe-transport'
 	]
 );
 style(


### PR DESCRIPTION
Gallery seems to reference an jquery.iframe-transport for the files app, which no longer exists in owncloud 9.1
