### PR TITLE
Block write-only shares

### DIFF
--- a/middleware/envcheckmiddleware.php
+++ b/middleware/envcheckmiddleware.php
@@ -16,6 +16,7 @@
 
 namespace OCA\Gallery\Middleware;
 
+use OCP\Constants;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\ISession;
@@ -162,6 +163,7 @@ class EnvCheckMiddleware extends CheckMiddleware {
 
 		$this->checkShareIsValid($share, $token);
 		$this->checkItemType($share);
+		$this->checkShareIsNotWriteOnly($share);
 
 		return $share;
 	}
@@ -196,6 +198,19 @@ class EnvCheckMiddleware extends CheckMiddleware {
 		if ($share->getNodeType() === null) {
 			$message = 'No item type set for share id: ' . $share->getId();
 			throw new CheckException($message, Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Makes sure the share is not write-only
+	 *
+	 * @param IShare $share
+	 *
+	 * @throws CheckException
+	 */
+	private function checkShareIsNotWriteOnly($share) {
+		if (!($share->getPermissions() & Constants::PERMISSION_READ)) {
+			throw new CheckException("Share is a write-only share", Http::STATUS_FORBIDDEN);
 		}
 	}
 

--- a/tests/unit/middleware/EnvCheckMiddlewareTest.php
+++ b/tests/unit/middleware/EnvCheckMiddlewareTest.php
@@ -194,6 +194,26 @@ class EnvCheckMiddlewareTest extends \Test\GalleryUnitTest {
 	 *
 	 * @expectedException \OCA\Gallery\Middleware\CheckException
 	 */
+	public function testBeforeControllerWithPublicNotationAndWriteOnlyToken() {
+		$this->reflector->reflect(__CLASS__, __FUNCTION__);
+
+		$token = 'aaaabbbbccccdddd';
+		$this->mockGetTokenParam($token);
+
+		$share = $this->mockShare(
+			'folder', 'tester', 'shared1', Share::SHARE_TYPE_LINK, null,
+			Constants::PERMISSION_CREATE, null
+		);
+		$this->mockShareManagerGetShareByToken($token, $share);
+
+		$this->middleware->beforeController(__CLASS__, __FUNCTION__);
+	}
+
+	/**
+	 * @PublicPage
+	 *
+	 * @expectedException \OCA\Gallery\Middleware\CheckException
+	 */
 	public function testBeforeControllerWithPublicNotationAndNoToken() {
 		$this->reflector->reflect(__CLASS__, __FUNCTION__);
 


### PR DESCRIPTION
Blocks access to write-only shares such as those created with the enterprise app `files_drop`
