### PR TITLE
Some breadcrumb fixes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -352,7 +352,3 @@ http://www.bypeople.com/author/comatosed/*/
 .mask.transparent {
 	opacity: 0;
 }
-
-.icon-loading-dark.small {
-	background-size: 16px;
-}

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -243,10 +243,13 @@
 			// We go through the array in reverse order
 			var crumbsElement = crumbs.get().reverse();
 			$(crumbsElement).each(function () {
-				$(this).click(self.showLoader);
 				if ($(this).hasClass('home')) {
 					$(this).show();
 					return;
+				}
+				// 1st sub-album has no-parent and the breadcrumbs contain home, ellipsis and last
+				if (self.breadcrumbs.length > 3) {
+					$(this).click(self.showLoader);
 				}
 				if ($(this).hasClass('ellipsis')) {
 					self.ellipsis = $(this);

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -245,6 +245,9 @@
 			$(crumbsElement).each(function () {
 				if ($(this).hasClass('home')) {
 					$(this).show();
+					if (self.breadcrumbs.length > 2) {
+						$(this).click(self.showLoader);
+					}
 					return;
 				}
 				// 1st sub-album has no-parent and the breadcrumbs contain home, ellipsis and last

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -112,7 +112,7 @@
 		 * Shows the dark spinner on the crumb
 		 */
 		showLoader: function () {
-			$(this).children('a').addClass("icon-loading-dark small");
+			$(this).addClass("icon-loading-small-dark");
 		},
 
 		/**

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -263,7 +263,9 @@
 				if (self.breadcrumbsElement.width() > availableWidth) {
 					shorten = true;
 					$(this).hide();
-					ellipsisPath = $(this).data('dir');
+					if (!ellipsisPath) {
+						ellipsisPath = $(this).data('dir');
+					}
 				}
 			});
 


### PR DESCRIPTION
Contains fixes for #638
- Disable spinner on current breadcrumb
- Fix the name of the album in the breadcrumbs ellipsis tooltip
- Replace our custom small-dark spinner with the official one
