### PR TITLE
after closing the image, the images list will stay in the same position.

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -363,8 +363,8 @@
 
 			// Only modern browsers can manipulate history
 			if (history && history.replaceState) {
-				// We simulate a click on the back button in order to be consistent
-				window.history.back();
+				// We stop displaying the image
+				$('#slideshow').css('display', 'none');
 			} else {
 				// For ancient browsers supported in core
 				this.stop();


### PR DESCRIPTION
Fixes: 26318 ( issue at owncloud/core )

(LINK : https://github.com/owncloud/core/issues/26318 ) 

Licence: MIT or AGPL

### Description
After clicking the exit button on the image pop-up, the list doesn't seem to stay at the same row, and this PR fixes that.

### Tested on

- [x] Ubuntu/Chrome

### TODO

- [ ] See if the documentation needs to be updated.
- [ ] See if any of the tests need to be updated.

### Check list

- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers
<!--
Please list below the Github handles of people suceptible to review this PR
-->
@PVince81 @DeepDiver1975 
