### PR TITLE
Do not show spinner when home is current and home clicked

### DIFF
--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -112,6 +112,9 @@
 		 * Shows the dark spinner on the crumb
 		 */
 		showLoader: function () {
+			if ($(this).hasClass('home') && $(this).hasClass('last')) {
+				return;
+			}
 			$(this).children('a').addClass("icon-loading-dark small");
 		},
 


### PR DESCRIPTION
Resubmit of https://github.com/owncloud/gallery/pull/755

Ref https://github.com/owncloud/enterprise/issues/2127
1. Open gallery
2. Click 'home' icon
3. See never ending spinner