### PR TITLE
Reformat .php_cs.dist to be similar to core

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,12 +1,13 @@
 <?php
 
-$config = new OC\CodingStandard\Config();
-
-$config
-    ->setUsingCache(true)
-    ->getFinder()
+$finder = PhpCsFixer\Finder::create()
 	->exclude('l10n')
 	->exclude('c3.php')
-    ->in(__DIR__);
+	->in(__DIR__);
+
+$config = new OC\CodingStandard\Config();
+$config
+    ->setUsingCache(true)
+    ->setFinder($finder);
 
 return $config;


### PR DESCRIPTION
Fixes #785 

This change reformats the ``.php_cs.dist`` to build its finder/exclude list in the same way that is done in ``core``, and it works.

No idea why the old way stopped working, I guess something happened in ``php-cs-fixer``  in the last few weeks.