### PR TITLE
Add the heic and heif image mimetypes to the gallery base mimetypes.

### DIFF
--- a/service/configservice.php
+++ b/service/configservice.php
@@ -52,6 +52,8 @@ class ConfigService extends FilesService {
 		'image/bmp',
 		'image/tiff',
 		'image/x-dcraw',
+		'image/heic',
+		'image/heif',
 		'application/x-photoshop',
 		'application/illustrator',
 		'application/postscript',


### PR DESCRIPTION
Fixes: https://github.com/owncloud/gallery/issues/737
Equivalent to: https://github.com/nextcloud/gallery/pull/464
Licence: MIT or AGPL

### Description
Adds the two mime types 'image/heic' and 'image/heif' to the default list of base types that can be shown in the gallery.

In order to make use of it, the server needs to provide a sufficiently up-to-date imagemagick installation with libheif support

### Features

* renders previews for HEIF images
* as well as shows the HEIF images in the slideshow

### Screenshots or screencasts

### Caveats

* ImageMagick with libheif support needs to be installed in the server.

## Tests

### Test plan
 - upload a test photo from iPhon to owncloud
 - make sure the thumbnail gets rendered in the files view and the file details show a preview already
 - enter the same folder in the gallery app view
   - make sure the thumbnail is shown in the gallery app
   - make sure a slideshow displays the image in full-screen too.

 
### Tested on

- [X] macOS / Safari
- [X] macOS / Firefox

### TODO

### Check list

- [ ] Code is properly documented
- [X] Code is properly formatted
- [X] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers