### PR TITLE
php-cs-fixer correctly exclude c3.php

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,7 +6,7 @@ $config
     ->setUsingCache(true)
 	->getFinder()
 	->exclude('l10n')
-	->exclude('c3.php')
+	->notPath('/^c3.php/')
 	->in(__DIR__);
 
 return $config;


### PR DESCRIPTION
Fixes: #808 

### Description
Exclude the top-level file ``c3.php`` from ``php-cs-fixer`` by specifying it using the ``notPath()`` method of Symfony Finder. This is the "proper" way to do this. The ``exclude()`` method is actually supposed to be for directories only, and it seems that in a more recent Symfony Finder version that it really is now only for directories.
