### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -89,11 +89,11 @@
 			var targetPath = $(event.target).data('dir').toString();
 			var dir = Gallery.currentAlbum;
 
-			while (dir.substr(0, 1) === '/') {//remove extra leading /'s
-				dir = dir.substr(1);
+			while (dir.slice(0, 1) === '/') {//remove extra leading /'s
+				dir = dir.slice(1);
 			}
 			dir = '/' + dir;
-			if (dir.substr(-1, 1) !== '/') {
+			if (dir.slice(-1) !== '/') {
 				dir = dir + '/';
 			}
 			// Do nothing if dragged on current dir


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.