### PR TITLE
Remove obsolete 'strict' from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="../../tests/bootstrap.php"
 		 verbose="true"
-		 strict="true"
 		 failOnRisky="true"
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"


### PR DESCRIPTION
### Description
Gets rid of messages in the unit test output: https://drone.owncloud.com/owncloud/gallery/381/2/5
```
 Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 9:
  - Element 'phpunit', attribute 'strict': The attribute 'strict' is not allowed.

  Test results may not be as expected.
```

I noticed this while starting to check the gallery app for any Guzzle5/6/7 issues.