### PR TITLE
docs: mark repository as archived and unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **⚠️ This repository is archived and no longer maintained.**
+> It is read-only and will not receive further updates or contributions.
+
 # Gallery 
 [![Build Status](https://drone.owncloud.com/api/badges/owncloud/gallery/status.svg?branch=master)](https://drone.owncloud.com/owncloud/gallery)
 


### PR DESCRIPTION
The repository is being archived and will no longer be maintained. This adds a deprecation notice to the top of the README before archiving.